### PR TITLE
Added Profile loading test for JSON boolean parsing issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,17 @@
 							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
 						</configuration>
 					</execution>
+					<execution>
+						<id>download-profile-json</id>
+						<phase>generate-test-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json</uri>
+							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/src/test/java/gov/nist/secauto/oscal/java/OscalLoaderTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/OscalLoaderTest.java
@@ -35,6 +35,7 @@ import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.binding.io.MutableConfiguration;
 import gov.nist.secauto.metaschema.binding.io.Serializer;
 import gov.nist.secauto.oscal.lib.model.Catalog;
+import gov.nist.secauto.oscal.lib.model.Profile;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -115,6 +116,31 @@ class OscalLoaderTest {
     serializer.serialize(catalog, out);
 
     assertNotNull(loader.loadCatalog(out));
+
+    // out.delete();
+  }
+
+  @Test
+  void testLoadProfileJson(@TempDir Path tempDir) throws BindingException, IOException {
+    Profile profile
+        = loader.load(new File("target/download/content/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json").getCanonicalFile());
+    assertNotNull(profile);
+
+    // File out = new File(tempDir.toFile(), "out.json");
+    File out = new File("target/out-profile.json");
+    BindingContext context = BindingContext.newInstance();
+    MutableConfiguration config
+        = new MutableConfiguration().enableFeature(Feature.SERIALIZE_ROOT).enableFeature(Feature.DESERIALIZE_ROOT);
+
+    Serializer<Profile> serializer = context.newSerializer(Format.JSON, Profile.class, config);
+    serializer.serialize(profile, out);
+
+    assertNotNull(loader.loadProfile(out));
+
+    out = new File("target/out-profile.yaml");
+
+    serializer = context.newSerializer(Format.YAML, Profile.class, config);
+    serializer.serialize(profile, out);
 
     // out.delete();
   }


### PR DESCRIPTION
# Committer Notes

Replicates the problem in #7 and passes when usnistgov/metaschema-java#13 is fixed, i.e. when building `metaschema-java` locally and updating the pom here to pull in version `0.5.1-SNAPSHOT`.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
