### PR TITLE
Add support for CycloneDX SBOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,9 @@
 		<dependency.metaschema-framework.version>0.5.0</dependency.metaschema-framework.version>
 		<dependency.jackson.version>2.12.1</dependency.jackson.version>
 
-    <plugin.license.version>4.0.rc1</plugin.license.version>
+		<plugin.license.version>4.0.rc1</plugin.license.version>
+		<cyclonedx.schema.version>1.3</cyclonedx.schema.version>
+		<cyclonedx.version>2.5.3</cyclonedx.version>
 
 		<oscal-content.commit>master</oscal-content.commit>
 	</properties>
@@ -193,7 +195,32 @@
 						<topSiteURL>${site.url}</topSiteURL>
 					</configuration>
 				</plugin>
-
+				<plugin>
+					<groupId>org.cyclonedx</groupId>
+					<artifactId>cyclonedx-maven-plugin</artifactId>
+					<version>${cyclonedx.version}</version>
+					<configuration>
+						<projectType>library</projectType>
+						<schemaVersion>${cyclonedx.schema.version}</schemaVersion>
+						<includeBomSerialNumber>true</includeBomSerialNumber>
+						<includeCompileScope>true</includeCompileScope>
+						<includeProvidedScope>true</includeProvidedScope>
+						<includeRuntimeScope>true</includeRuntimeScope>
+						<includeSystemScope>true</includeSystemScope>
+						<includeTestScope>false</includeTestScope>
+						<includeLicenseText>false</includeLicenseText>
+						<outputFormat>all</outputFormat>
+						<outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>makeBom</goal>
+							</goals>
+							<phase>verify</phase>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -282,6 +309,10 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.cyclonedx</groupId>
+				<artifactId>cyclonedx-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
# Committer Notes

This adds support for generation of a SBOM on build. No code changes, just adds the plugin + config to pom.xml.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
