### PR TITLE
Correct OSCAL version handling in resolved profile

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/lib/OscalUtils.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/OscalUtils.java
@@ -43,7 +43,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class OscalUtils {
-  public static final String OSCAL_VERSION = "1.0.0";
+  public static final String OSCAL_VERSION = "1.0.4";
   private static final Pattern INTERNAL_REFERENCE_FRAGMENT_PATTERN = Pattern.compile("^#(.+)$");
 
   private OscalUtils() {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
@@ -152,7 +152,7 @@ public class ProfileResolver {
     } else {
       version = Version.unknownVersion();
     }
-    metadata.setOscalVersion(version.toString());
+    metadata.setVersion(version.toString());
 
     resolveImports(data);
     handleMerge(data);

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
@@ -26,6 +26,8 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import gov.nist.secauto.metaschema.binding.io.BindingException;
@@ -60,6 +62,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.util.Stack;
 
@@ -96,6 +99,15 @@ class ProfileResolutionTests {
 
   public static ProfileResolver getProfileResolver() {
     return profileResolver;
+  }
+
+  private Catalog resolveProfile(@NotNull Path profileFile)
+      throws FileNotFoundException, BindingException, IOException {
+    Profile profile = OscalBindingContext.instance().loadProfile(profileFile);
+    ProfileResolver.ResolutionData data
+        = new ProfileResolver.ResolutionData(profile, ObjectUtils.notNull(profileFile.toUri()), new Stack<>());
+    getProfileResolver().resolve(data);
+    return data.getCatalog();
   }
 
   private Catalog resolveProfile(@NotNull File profileFile)
@@ -178,4 +190,14 @@ class ProfileResolutionTests {
 
     MatcherAssert.assertThat(exceptionThrown.getCause(), CoreMatchers.instanceOf(ImportCycleException.class));
   }
+
+
+  @Test
+  void testOscalVersion() throws IllegalStateException, IOException, BindingException {
+    Path profileFile = Path.of("src/test/resources/test-oscal-version-profile.xml");
+    Catalog catalog = resolveProfile(profileFile);
+    assertNotNull(catalog);
+    assertEquals("1.0.4", catalog.getMetadata().getOscalVersion());
+  }
+
 }

--- a/src/test/resources/test-oscal-version-profile.xml
+++ b/src/test/resources/test-oscal-version-profile.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../oscal/src/specification/profile-resolution/example-checkup.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- Modified by conversion XSLT 2021-04-05T11:22:07.701-04:00 - RC2 OSCAL becomes RC3 OSCAL -->
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+         uuid="cb1ec926-3441-458f-8cce-ea11308c9d37">
+   <metadata>
+      <title>Test Profile</title>
+      <last-modified>2020-05-30T14:39:35.84-04:00</last-modified>
+      <version>2.3.4</version>
+      <oscal-version>1.0.3</oscal-version>
+   </metadata>
+   <import href="../../../oscal/src/specifications/profile-resolution/profile-resolution-examples/catalogs/abc-simple_catalog.xml">
+      <include-controls with-child-controls="yes">
+         <with-id>a1</with-id>
+         <with-id>b1</with-id>
+         <with-id>c1</with-id>
+         <with-id>c3</with-id>
+      </include-controls>
+   </import>
+</profile>

--- a/src/test/resources/test-oscal-version-profile.xml
+++ b/src/test/resources/test-oscal-version-profile.xml
@@ -7,7 +7,7 @@
       <title>Test Profile</title>
       <last-modified>2020-05-30T14:39:35.84-04:00</last-modified>
       <version>2.3.4</version>
-      <oscal-version>1.0.3</oscal-version>
+      <oscal-version>1.0.4</oscal-version>
    </metadata>
    <import href="../../../oscal/src/specifications/profile-resolution/profile-resolution-examples/catalogs/abc-simple_catalog.xml">
       <include-controls with-child-controls="yes">


### PR DESCRIPTION
# Committer Notes

Corrected metadata/oscal-version handling bug to use OSCAL version, not the content version from a source profile. Resolves #15.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
