### PR TITLE
Support alter `set-parameter`, `add`, and `remove` functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -13,7 +14,9 @@
 	<packaging>jar</packaging>
 
 	<name>OSCAL Java Library</name>
-	<description>A Java library that parses XML, JSON, and YAML data formatted acording to a Metaschema-based model.</description>
+	<description>A Java library that parses XML, JSON, and YAML data
+		formatted acording to a Metaschema-based model.
+	</description>
 	<url>https://github.com/usnistgov/liboscal-java</url>
 
 	<issueManagement>
@@ -23,10 +26,12 @@
 
 	<scm>
 		<url>https://github.com/usnistgov/liboscal-java</url>
-		<connection>scm:git:git@github.com:usnistgov/liboscal-java.git</connection>
-		<developerConnection>scm:git:git@github.com:usnistgov/liboscal-java.git</developerConnection>
-	  <tag>v1.0.4</tag>
-  </scm>
+		<connection>scm:git:git@github.com:usnistgov/liboscal-java.git
+		</connection>
+		<developerConnection>scm:git:git@github.com:usnistgov/liboscal-java.git
+		</developerConnection>
+		<tag>v1.0.4</tag>
+	</scm>
 
 	<distributionManagement>
 		<snapshotRepository>
@@ -35,7 +40,8 @@
 		</snapshotRepository>
 		<repository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
+			</url>
 		</repository>
 		<site>
 			<id>nist-pages</id>
@@ -62,7 +68,8 @@
 			<id>david.waltermire@nist.gov</id>
 			<name>David Waltermire</name>
 			<email>david.waltermire@nist.gov</email>
-			<organization>National Institute of Standards and Technology</organization>
+			<organization>National Institute of Standards and Technology
+			</organization>
 			<roles>
 				<role>architect</role>
 				<role>developer</role>
@@ -115,16 +122,23 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<dependency.metaschema-framework.version>0.9.0-SNAPSHOT</dependency.metaschema-framework.version>
+
+		<dependency.auto-service.version>1.0.1</dependency.auto-service.version>
+		<dependency.commons-lang3.version>3.12.0</dependency.commons-lang3.version>
+		<dependency.infinispan.version>13.0.10.Final</dependency.infinispan.version>
 		<dependency.jetbrains-annotation.version>23.0.0</dependency.jetbrains-annotation.version>
 		<dependency.jmock-junit5.version>2.12.0</dependency.jmock-junit5.version>
 		<dependency.junit5.version>5.8.2</dependency.junit5.version>
 		<dependency.junit5-platform-launcher.version>1.8.2</dependency.junit5-platform-launcher.version>
+		<dependency.log4j2.version>2.18.0</dependency.log4j2.version>
 		<dependency.saxon.version>11.3</dependency.saxon.version>
+		<dependency.spotbugs-annotations.version>4.2.0</dependency.spotbugs-annotations.version>
 		<dependency.xmlresolver.version>4.4.0</dependency.xmlresolver.version>
 
 		<plugin.license.version>4.0.rc1</plugin.license.version>
 		<cyclonedx.schema.version>1.3</cyclonedx.schema.version>
 		<plugin.cyclonedx.version>2.7.0</plugin.cyclonedx.version>
+		<spotbugs-maven-plugin.version>4.7.1.1</spotbugs-maven-plugin.version>
 
 		<oscal-content.commit>master</oscal-content.commit>
 	</properties>
@@ -161,6 +175,32 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>gov.nist.secauto.metaschema</groupId>
+				<artifactId>metaschema-java-binding</artifactId>
+				<version>${dependency.metaschema-framework.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.auto.service</groupId>
+				<artifactId>auto-service</artifactId>
+				<version>${dependency.auto-service.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>${dependency.commons-lang3.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${dependency.log4j2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>${dependency.log4j2.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.xmlresolver</groupId>
 				<artifactId>xmlresolver</artifactId>
 				<version>${dependency.xmlresolver.version}</version>
@@ -185,6 +225,13 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<dependency>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-annotations</artifactId>
+				<version>${dependency.spotbugs-annotations.version}</version>
+				<scope>provided</scope>
+				<optional>true</optional>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -192,24 +239,37 @@
 		<dependency>
 			<groupId>gov.nist.secauto.metaschema</groupId>
 			<artifactId>metaschema-java-binding</artifactId>
-			<version>${dependency.metaschema-framework.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-			<version>${dependency.jetbrains-annotation.version}</version>
-			<scope>provided</scope>
+			<groupId>com.google.auto.service</groupId>
+			<artifactId>auto-service</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -260,7 +320,8 @@
 				<directory>src/main/resources</directory>
 			</resource>
 			<resource>
-				<directory>${project.build.directory}/generated-resources/oscal</directory>
+				<directory>${project.build.directory}/generated-resources/oscal
+				</directory>
 				<includes>
 					<include>**/*.xsd</include>
 					<include>**/*.json</include>
@@ -289,8 +350,10 @@
 					<artifactId>maven-checkstyle-plugin</artifactId>
 					<configuration>
 						<sourceDirectories>
-							<sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-							<sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+							<sourceDirectory>${project.build.sourceDirectory}
+							</sourceDirectory>
+							<sourceDirectory>${project.build.testSourceDirectory}
+							</sourceDirectory>
 						</sourceDirectories>
 					</configuration>
 				</plugin>
@@ -325,7 +388,8 @@
 						<includeTestScope>false</includeTestScope>
 						<includeLicenseText>false</includeLicenseText>
 						<outputFormat>all</outputFormat>
-						<outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
+						<outputName>${project.artifactId}-${project.version}-cyclonedx
+						</outputName>
 					</configuration>
 					<executions>
 						<execution>
@@ -335,6 +399,13 @@
 							</goals>
 						</execution>
 					</executions>
+				</plugin>
+				<plugin>
+					<groupId>com.github.spotbugs</groupId>
+					<artifactId>spotbugs-maven-plugin</artifactId>
+					<configuration>
+						<excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -346,7 +417,8 @@
 				<configuration>
 					<dotGitDirectory>${project.basedir}/oscal/.git</dotGitDirectory>
 					<generateGitPropertiesFile>true</generateGitPropertiesFile>
-					<generateGitPropertiesFilename>${project.build.directory}/oscal-git.properties</generateGitPropertiesFilename>
+					<generateGitPropertiesFilename>${project.build.directory}/oscal-git.properties
+					</generateGitPropertiesFilename>
 					<verbose>true</verbose>
 					<useNativeGit>false</useNativeGit>
 					<prefix>oscal-git</prefix>
@@ -372,7 +444,8 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.directory}/generated-resources/oscal/schema/xml</outputDirectory>
+							<outputDirectory>${project.build.directory}/generated-resources/oscal/schema/xml
+							</outputDirectory>
 							<resources>
 								<resource>
 									<directory>${project.basedir}/oscal/xml/schema</directory>
@@ -387,7 +460,8 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.directory}/generated-resources/oscal/schema/json</outputDirectory>
+							<outputDirectory>${project.build.directory}/generated-resources/oscal/schema/json
+							</outputDirectory>
 							<resources>
 								<resource>
 									<directory>${project.basedir}/oscal/json/schema</directory>
@@ -426,8 +500,10 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml</uri>
-							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
+							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_catalog.xml
+							</uri>
+							<outputDirectory>${project.build.directory}/download/content
+							</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -437,8 +513,10 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json</uri>
-							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
+							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json
+							</uri>
+							<outputDirectory>${project.build.directory}/download/content
+							</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -448,8 +526,10 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/yaml/NIST_SP-800-53_rev5_catalog.yaml</uri>
-							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
+							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/yaml/NIST_SP-800-53_rev5_catalog.yaml
+							</uri>
+							<outputDirectory>${project.build.directory}/download/content
+							</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -459,8 +539,10 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_LOW-baseline_profile.xml</uri>
-							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
+							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_LOW-baseline_profile.xml
+							</uri>
+							<outputDirectory>${project.build.directory}/download/content
+							</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -470,8 +552,10 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json</uri>
-							<outputDirectory>${project.build.directory}/download/content</outputDirectory>
+							<uri>https://raw.githubusercontent.com/usnistgov/oscal-content/${oscal-content.commit}/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline_profile.json
+							</uri>
+							<outputDirectory>${project.build.directory}/download/content
+							</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -487,9 +571,11 @@
 							<goal>generate-sources</goal>
 						</goals>
 						<configuration>
-							<metaschemaDir>${project.basedir}/oscal/src/metaschema</metaschemaDir>
+							<metaschemaDir>${project.basedir}/oscal/src/metaschema
+							</metaschemaDir>
 							<configs>
-								<config>${project.basedir}/src/main/metaschema-bindings/oscal-metaschema-bindings.xml</config>
+								<config>${project.basedir}/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
+								</config>
 							</configs>
 							<includes>
 								<include>oscal_complete_metaschema.xml</include>
@@ -510,7 +596,8 @@
 						</goals>
 						<configuration>
 							<sources>
-								<source>${project.build.directory}/generated-sources/metaschema</source>
+								<source>${project.build.directory}/generated-sources/metaschema
+								</source>
 							</sources>
 						</configuration>
 					</execution>
@@ -523,7 +610,8 @@
 						<configuration>
 							<resources>
 								<resource>
-									<directory>${project.build.directory}/generated-resources/oscal</directory>
+									<directory>${project.build.directory}/generated-resources/oscal
+									</directory>
 									<includes>
 										<include>**/*.xsd</include>
 										<include>**/*.json</include>
@@ -532,11 +620,22 @@
 							</resources>
 						</configuration>
 					</execution>
-					<!-- <execution> <id>attach-artifacts</id> <phase>package</phase> <goals> 
-						<goal>attach-artifact</goal> </goals> <configuration> <artifacts> <artifact> 
-						<file>${project.build.directory}/</file> <type>xml</type> <classifier>optional</classifier> 
-						</artifact> ... </artifacts> </configuration> </execution> -->
+					<!-- <execution> <id>attach-artifacts</id> <phase>package</phase> <goals> <goal>attach-artifact</goal> </goals> <configuration> 
+						<artifacts> <artifact> <file>${project.build.directory}/</file> <type>xml</type> <classifier>optional</classifier> </artifact> 
+						... </artifacts> </configuration> </execution> -->
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<configuration>
+					<ignoredDependencies>
+						<ignoredDependency>com.google.auto.service:auto-service</ignoredDependency>
+					</ignoredDependencies>
+					<usedDependencies>
+						<usedDependency>org.apache.logging.log4j:log4j-core</usedDependency>
+					</usedDependencies>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>
@@ -548,6 +647,23 @@
 					<plugin>
 						<groupId>org.cyclonedx</groupId>
 						<artifactId>cyclonedx-maven-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<version>${spotbugs-maven-plugin.version}</version>
+						<configuration>
+							<effort>Max</effort>
+							<threshold>Normal</threshold>
+							<xmlOutput>true</xmlOutput>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>
@@ -578,6 +694,11 @@
 								</reports>
 							</reportSet>
 						</reportSets>
+					</plugin>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<version>${spotbugs-maven-plugin.version}</version>
 					</plugin>
 				</plugins>
 			</reporting>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+	xmlns="https://github.com/spotbugs/filter/3.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+	<Match>
+		<Or>
+			<Package name="gov.nist.secauto.oscal.lib.model" />
+			<Package name="~gov\.nist\.secauto\.oscal\.lib\.model\..*" />
+		</Or>
+		<Or>
+			<Bug pattern="EI_EXPOSE_REP" />
+			<Bug pattern="EI_EXPOSE_REP2" />
+		</Or>
+	</Match>
+	<Match>
+		<Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+	</Match>
+</FindBugsFilter>

--- a/src/main/java/gov/nist/secauto/oscal/lib/OscalBindingContext.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/OscalBindingContext.java
@@ -33,11 +33,10 @@ import gov.nist.secauto.oscal.lib.model.AssessmentPlan;
 import gov.nist.secauto.oscal.lib.model.AssessmentResults;
 import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.model.ComponentDefinition;
+import gov.nist.secauto.oscal.lib.model.MappingCollection;
 import gov.nist.secauto.oscal.lib.model.PlanOfActionAndMilestones;
 import gov.nist.secauto.oscal.lib.model.Profile;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
-
-import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,14 +47,16 @@ import java.util.Set;
 
 import javax.xml.namespace.QName;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public class OscalBindingContext
     extends DefaultBindingContext {
-  @Nonnull
-  private static final OscalBindingContext INSTANCE = new OscalBindingContext();
+  @NonNull
+  private static final OscalBindingContext SINGLETON = new OscalBindingContext();
 
-  @Nonnull
+  @NonNull
   public static OscalBindingContext instance() {
-    return INSTANCE;
+    return SINGLETON;
   }
 
   /**
@@ -64,7 +65,7 @@ public class OscalBindingContext
    * @param constraintSets
    *          a set of additional constraints to apply
    */
-  public OscalBindingContext(@Nonnull Set<@Nonnull IConstraintSet> constraintSets) {
+  public OscalBindingContext(@NonNull Set<IConstraintSet> constraintSets) {
     super(constraintSets);
     registerBindingMatcher(new Matcher());
   }
@@ -76,115 +77,128 @@ public class OscalBindingContext
     registerBindingMatcher(new Matcher());
   }
 
-  @Nonnull
-  public Catalog loadCatalog(@Nonnull URL url) throws IOException, URISyntaxException {
+  @NonNull
+  public Catalog loadCatalog(@NonNull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(Catalog.class, url);
   }
 
-  @Nonnull
-  public Catalog loadCatalog(@Nonnull Path path) throws IOException {
+  @NonNull
+  public Catalog loadCatalog(@NonNull Path path) throws IOException {
     return newBoundLoader().load(Catalog.class, path);
   }
 
-  @SuppressWarnings("null")
-  @Nonnull
-  public Catalog loadCatalog(@Nonnull File file) throws IOException {
-    return loadCatalog(file.toPath());
+  @NonNull
+  public Catalog loadCatalog(@NonNull File file) throws IOException {
+    return newBoundLoader().load(Catalog.class, file);
   }
 
-  @Nonnull
-  public Profile loadProfile(@Nonnull URL url) throws IOException, URISyntaxException {
+  @NonNull
+  public Profile loadProfile(@NonNull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(Profile.class, url);
   }
 
-  @Nonnull
-  public Profile loadProfile(@Nonnull Path path) throws IOException {
+  @NonNull
+  public Profile loadProfile(@NonNull Path path) throws IOException {
     return newBoundLoader().load(Profile.class, path);
   }
 
-  @Nonnull
-  public Profile loadProfile(@Nonnull File file) throws IOException {
+  @NonNull
+  public Profile loadProfile(@NonNull File file) throws IOException {
     return newBoundLoader().load(Profile.class, file);
   }
 
-  @Nonnull
-  public SystemSecurityPlan loadSystemSecurityPlan(@Nonnull URL url) throws IOException, URISyntaxException {
+  @NonNull
+  public MappingCollection loadMapping(@NonNull URL url) throws IOException, URISyntaxException {
+    return newBoundLoader().load(MappingCollection.class, url);
+  }
+
+  @NonNull
+  public MappingCollection loadMapping(@NonNull Path path) throws IOException {
+    return newBoundLoader().load(MappingCollection.class, path);
+  }
+
+  @NonNull
+  public MappingCollection loadMapping(@NonNull File file) throws IOException {
+    return newBoundLoader().load(MappingCollection.class, file);
+  }
+
+  @NonNull
+  public SystemSecurityPlan loadSystemSecurityPlan(@NonNull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(SystemSecurityPlan.class, url);
   }
 
-  @Nonnull
-  public SystemSecurityPlan loadSystemSecurityPlan(@Nonnull Path path) throws IOException {
+  @NonNull
+  public SystemSecurityPlan loadSystemSecurityPlan(@NonNull Path path) throws IOException {
     return newBoundLoader().load(SystemSecurityPlan.class, path);
   }
 
-  @Nonnull
-  public SystemSecurityPlan loadSystemSecurityPlan(@Nonnull File file) throws IOException {
+  @NonNull
+  public SystemSecurityPlan loadSystemSecurityPlan(@NonNull File file) throws IOException {
     return newBoundLoader().load(SystemSecurityPlan.class, file);
   }
 
-  @Nonnull
-  public ComponentDefinition loadComponentDefinition(@Nonnull URL url) throws IOException, URISyntaxException {
+  @NonNull
+  public ComponentDefinition loadComponentDefinition(@NonNull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(ComponentDefinition.class, url);
   }
 
-  @Nonnull
-  public ComponentDefinition loadComponentDefinition(@Nonnull Path path) throws IOException {
+  @NonNull
+  public ComponentDefinition loadComponentDefinition(@NonNull Path path) throws IOException {
     return newBoundLoader().load(ComponentDefinition.class, path);
   }
 
-  @Nonnull
-  public ComponentDefinition loadComponentDefinition(@Nonnull File file) throws IOException {
+  @NonNull
+  public ComponentDefinition loadComponentDefinition(@NonNull File file) throws IOException {
     return newBoundLoader().load(ComponentDefinition.class, file);
   }
 
-  @Nonnull
-  public AssessmentPlan loadAssessmentPlan(@Nonnull URL url) throws IOException, URISyntaxException {
+  @NonNull
+  public AssessmentPlan loadAssessmentPlan(@NonNull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(AssessmentPlan.class, url);
   }
 
-  @Nonnull
-  public AssessmentPlan loadAssessmentPlan(@Nonnull Path path) throws IOException {
+  @NonNull
+  public AssessmentPlan loadAssessmentPlan(@NonNull Path path) throws IOException {
     return newBoundLoader().load(AssessmentPlan.class, path);
   }
 
-  @Nonnull
-  public AssessmentPlan loadAssessmentPlan(@Nonnull File file) throws IOException {
+  @NonNull
+  public AssessmentPlan loadAssessmentPlan(@NonNull File file) throws IOException {
     return newBoundLoader().load(AssessmentPlan.class, file);
   }
 
-  @Nonnull
-  public AssessmentResults loadAssessmentResults(@Nonnull URL url) throws IOException, URISyntaxException {
+  @NonNull
+  public AssessmentResults loadAssessmentResults(@NonNull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(AssessmentResults.class, url);
   }
 
-  @Nonnull
-  public AssessmentResults loadAssessmentResults(@Nonnull Path path) throws IOException {
+  @NonNull
+  public AssessmentResults loadAssessmentResults(@NonNull Path path) throws IOException {
     return newBoundLoader().load(AssessmentResults.class, path);
   }
 
-  @Nonnull
-  public AssessmentResults loadAssessmentResults(@Nonnull File file) throws IOException {
+  @NonNull
+  public AssessmentResults loadAssessmentResults(@NonNull File file) throws IOException {
     return newBoundLoader().load(AssessmentResults.class, file);
   }
 
-  @Nonnull
-  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@Nonnull URL url)
+  @NonNull
+  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@NonNull URL url)
       throws IOException, URISyntaxException {
     return newBoundLoader().load(PlanOfActionAndMilestones.class, url);
   }
 
-  @Nonnull
-  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@Nonnull Path path) throws IOException {
+  @NonNull
+  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@NonNull Path path) throws IOException {
     return newBoundLoader().load(PlanOfActionAndMilestones.class, path);
   }
 
-  @Nonnull
-  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@Nonnull File file) throws IOException {
+  @NonNull
+  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@NonNull File file) throws IOException {
     return newBoundLoader().load(PlanOfActionAndMilestones.class, file);
   }
 
-  private class Matcher implements IBindingMatcher {
-
+  private static class Matcher implements IBindingMatcher {
     @Override
     public Class<?> getBoundClassForXmlQName(QName startElementQName) {
       Class<?> clazz = null;
@@ -195,6 +209,9 @@ public class OscalBindingContext
           break;
         case "profile":
           clazz = Profile.class;
+          break;
+        case "mapping-collection":
+          clazz = MappingCollection.class;
           break;
         case "system-security-plan":
           clazz = SystemSecurityPlan.class;

--- a/src/main/java/gov/nist/secauto/oscal/lib/OscalBindingContext.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/OscalBindingContext.java
@@ -37,7 +37,7 @@ import gov.nist.secauto.oscal.lib.model.PlanOfActionAndMilestones;
 import gov.nist.secauto.oscal.lib.model.Profile;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,10 +50,10 @@ import javax.xml.namespace.QName;
 
 public class OscalBindingContext
     extends DefaultBindingContext {
-  @NotNull
+  @Nonnull
   private static final OscalBindingContext INSTANCE = new OscalBindingContext();
 
-  @NotNull
+  @Nonnull
   public static OscalBindingContext instance() {
     return INSTANCE;
   }
@@ -64,7 +64,7 @@ public class OscalBindingContext
    * @param constraintSets
    *          a set of additional constraints to apply
    */
-  public OscalBindingContext(@NotNull Set<@NotNull IConstraintSet> constraintSets) {
+  public OscalBindingContext(@Nonnull Set<@Nonnull IConstraintSet> constraintSets) {
     super(constraintSets);
     registerBindingMatcher(new Matcher());
   }
@@ -76,110 +76,110 @@ public class OscalBindingContext
     registerBindingMatcher(new Matcher());
   }
 
-  @NotNull
-  public Catalog loadCatalog(@NotNull URL url) throws IOException, URISyntaxException {
+  @Nonnull
+  public Catalog loadCatalog(@Nonnull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(Catalog.class, url);
   }
 
-  @NotNull
-  public Catalog loadCatalog(@NotNull Path path) throws IOException {
+  @Nonnull
+  public Catalog loadCatalog(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(Catalog.class, path);
   }
 
   @SuppressWarnings("null")
-  @NotNull
-  public Catalog loadCatalog(@NotNull File file) throws IOException {
+  @Nonnull
+  public Catalog loadCatalog(@Nonnull File file) throws IOException {
     return loadCatalog(file.toPath());
   }
 
-  @NotNull
-  public Profile loadProfile(@NotNull URL url) throws IOException, URISyntaxException {
+  @Nonnull
+  public Profile loadProfile(@Nonnull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(Profile.class, url);
   }
 
-  @NotNull
-  public Profile loadProfile(@NotNull Path path) throws IOException {
+  @Nonnull
+  public Profile loadProfile(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(Profile.class, path);
   }
 
-  @NotNull
-  public Profile loadProfile(@NotNull File file) throws IOException {
+  @Nonnull
+  public Profile loadProfile(@Nonnull File file) throws IOException {
     return newBoundLoader().load(Profile.class, file);
   }
 
-  @NotNull
-  public SystemSecurityPlan loadSystemSecurityPlan(@NotNull URL url) throws IOException, URISyntaxException {
+  @Nonnull
+  public SystemSecurityPlan loadSystemSecurityPlan(@Nonnull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(SystemSecurityPlan.class, url);
   }
 
-  @NotNull
-  public SystemSecurityPlan loadSystemSecurityPlan(@NotNull Path path) throws IOException {
+  @Nonnull
+  public SystemSecurityPlan loadSystemSecurityPlan(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(SystemSecurityPlan.class, path);
   }
 
-  @NotNull
-  public SystemSecurityPlan loadSystemSecurityPlan(@NotNull File file) throws IOException {
+  @Nonnull
+  public SystemSecurityPlan loadSystemSecurityPlan(@Nonnull File file) throws IOException {
     return newBoundLoader().load(SystemSecurityPlan.class, file);
   }
 
-  @NotNull
-  public ComponentDefinition loadComponentDefinition(@NotNull URL url) throws IOException, URISyntaxException {
+  @Nonnull
+  public ComponentDefinition loadComponentDefinition(@Nonnull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(ComponentDefinition.class, url);
   }
 
-  @NotNull
-  public ComponentDefinition loadComponentDefinition(@NotNull Path path) throws IOException {
+  @Nonnull
+  public ComponentDefinition loadComponentDefinition(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(ComponentDefinition.class, path);
   }
 
-  @NotNull
-  public ComponentDefinition loadComponentDefinition(@NotNull File file) throws IOException {
+  @Nonnull
+  public ComponentDefinition loadComponentDefinition(@Nonnull File file) throws IOException {
     return newBoundLoader().load(ComponentDefinition.class, file);
   }
 
-  @NotNull
-  public AssessmentPlan loadAssessmentPlan(@NotNull URL url) throws IOException, URISyntaxException {
+  @Nonnull
+  public AssessmentPlan loadAssessmentPlan(@Nonnull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(AssessmentPlan.class, url);
   }
 
-  @NotNull
-  public AssessmentPlan loadAssessmentPlan(@NotNull Path path) throws IOException {
+  @Nonnull
+  public AssessmentPlan loadAssessmentPlan(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(AssessmentPlan.class, path);
   }
 
-  @NotNull
-  public AssessmentPlan loadAssessmentPlan(@NotNull File file) throws IOException {
+  @Nonnull
+  public AssessmentPlan loadAssessmentPlan(@Nonnull File file) throws IOException {
     return newBoundLoader().load(AssessmentPlan.class, file);
   }
 
-  @NotNull
-  public AssessmentResults loadAssessmentResults(@NotNull URL url) throws IOException, URISyntaxException {
+  @Nonnull
+  public AssessmentResults loadAssessmentResults(@Nonnull URL url) throws IOException, URISyntaxException {
     return newBoundLoader().load(AssessmentResults.class, url);
   }
 
-  @NotNull
-  public AssessmentResults loadAssessmentResults(@NotNull Path path) throws IOException {
+  @Nonnull
+  public AssessmentResults loadAssessmentResults(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(AssessmentResults.class, path);
   }
 
-  @NotNull
-  public AssessmentResults loadAssessmentResults(@NotNull File file) throws IOException {
+  @Nonnull
+  public AssessmentResults loadAssessmentResults(@Nonnull File file) throws IOException {
     return newBoundLoader().load(AssessmentResults.class, file);
   }
 
-  @NotNull
-  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@NotNull URL url)
+  @Nonnull
+  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@Nonnull URL url)
       throws IOException, URISyntaxException {
     return newBoundLoader().load(PlanOfActionAndMilestones.class, url);
   }
 
-  @NotNull
-  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@NotNull Path path) throws IOException {
+  @Nonnull
+  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@Nonnull Path path) throws IOException {
     return newBoundLoader().load(PlanOfActionAndMilestones.class, path);
   }
 
-  @NotNull
-  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@NotNull File file) throws IOException {
+  @Nonnull
+  public PlanOfActionAndMilestones loadPlanOfActionAndMilestones(@Nonnull File file) throws IOException {
     return newBoundLoader().load(PlanOfActionAndMilestones.class, file);
   }
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/OscalUtils.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/OscalUtils.java
@@ -33,7 +33,7 @@ import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource.Base64;
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource.Rlink;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.Nullable;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
@@ -55,7 +55,7 @@ public final class OscalUtils {
     // disable construction
   }
 
-  public static boolean isInternalReference(@NotNull URI uri) {
+  public static boolean isInternalReference(@Nonnull URI uri) {
     if (uri.isAbsolute()) {
       return false;
     }
@@ -66,13 +66,13 @@ public final class OscalUtils {
   }
 
   @SuppressWarnings("null")
-  @NotNull
-  public static String internalReferenceFragmentToId(@NotNull URI fragment) throws IllegalArgumentException {
+  @Nonnull
+  public static String internalReferenceFragmentToId(@Nonnull URI fragment) throws IllegalArgumentException {
     return internalReferenceFragmentToId(fragment.toString());
   }
 
-  @NotNull
-  public static String internalReferenceFragmentToId(@NotNull String fragment) throws IllegalArgumentException {
+  @Nonnull
+  public static String internalReferenceFragmentToId(@Nonnull String fragment) throws IllegalArgumentException {
     Matcher matcher = INTERNAL_REFERENCE_FRAGMENT_PATTERN.matcher(fragment);
     String retval;
     if (matcher.matches()) {
@@ -84,12 +84,12 @@ public final class OscalUtils {
     return retval;
   }
 
-  public static boolean hasBase64Data(@NotNull Resource resource) {
+  public static boolean hasBase64Data(@Nonnull Resource resource) {
     return resource.getBase64() != null;
   }
 
   @Nullable
-  public static ByteBuffer getBase64Data(@NotNull Resource resource) {
+  public static ByteBuffer getBase64Data(@Nonnull Resource resource) {
     Base64 base64 = resource.getBase64();
 
     ByteBuffer retval = null;
@@ -100,7 +100,7 @@ public final class OscalUtils {
   }
 
   @Nullable
-  public static URI getResourceURI(@NotNull Resource resource, @Nullable String preferredMediaType) {
+  public static URI getResourceURI(@Nonnull Resource resource, @Nullable String preferredMediaType) {
     URI retval;
     if (hasBase64Data(resource)) {
       UUID uuid = resource.getUuid();
@@ -116,7 +116,7 @@ public final class OscalUtils {
   }
 
   @Nullable
-  public static Rlink findMatchingRLink(@NotNull Resource resource, @Nullable String preferredMediaType) {
+  public static Rlink findMatchingRLink(@Nonnull Resource resource, @Nullable String preferredMediaType) {
     // find a suitable rlink reference
     List<Rlink> rlinks = resource.getRlinks();
 
@@ -136,7 +136,7 @@ public final class OscalUtils {
   }
 
   @Nullable
-  public static InputSource newInputSource(@NotNull Resource resource, @NotNull EntityResolver resolver,
+  public static InputSource newInputSource(@Nonnull Resource resource, @Nonnull EntityResolver resolver,
       @Nullable String preferredMediaType) throws IOException {
     URI uri = getResourceURI(resource, null);
     if (uri == null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/OscalUtils.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/OscalUtils.java
@@ -33,8 +33,7 @@ import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource.Base64;
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource.Rlink;
 
-import javax.annotation.Nonnull;
-import org.jetbrains.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -47,6 +46,8 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public final class OscalUtils {
   public static final String OSCAL_VERSION = "1.0.4";
   private static final Pattern INTERNAL_REFERENCE_FRAGMENT_PATTERN = Pattern.compile("^#(.+)$");
@@ -55,9 +56,9 @@ public final class OscalUtils {
     // disable construction
   }
 
-  public static boolean isInternalReference(@Nonnull URI uri) {
+  public static boolean isInternalReference(@NonNull URI uri) {
     if (uri.isAbsolute()) {
-      return false;
+      return false; // NOPMD - readability
     }
 
     String schemeSpecificPart = uri.getSchemeSpecificPart();
@@ -65,14 +66,31 @@ public final class OscalUtils {
         && uri.getFragment() != null;
   }
 
-  @SuppressWarnings("null")
-  @Nonnull
-  public static String internalReferenceFragmentToId(@Nonnull URI fragment) throws IllegalArgumentException {
+  /**
+   * Get the id based on a URI's fragment.
+   * 
+   * @param fragment
+   *          the URI to extract the identifier from
+   * @return the identifier
+   * @throws IllegalArgumentException
+   *           if the fragment does not contain an identifier
+   */
+  @NonNull
+  public static String internalReferenceFragmentToId(@NonNull URI fragment) {
     return internalReferenceFragmentToId(fragment.toString());
   }
 
-  @Nonnull
-  public static String internalReferenceFragmentToId(@Nonnull String fragment) throws IllegalArgumentException {
+  /**
+   * Get the id based on a URI's fragment.
+   * 
+   * @param fragment
+   *          the URI to extract the identifier from
+   * @return the identifier
+   * @throws IllegalArgumentException
+   *           if the fragment does not contain an identifier
+   */
+  @NonNull
+  public static String internalReferenceFragmentToId(@NonNull String fragment) {
     Matcher matcher = INTERNAL_REFERENCE_FRAGMENT_PATTERN.matcher(fragment);
     String retval;
     if (matcher.matches()) {
@@ -84,12 +102,12 @@ public final class OscalUtils {
     return retval;
   }
 
-  public static boolean hasBase64Data(@Nonnull Resource resource) {
+  public static boolean hasBase64Data(@NonNull Resource resource) {
     return resource.getBase64() != null;
   }
 
   @Nullable
-  public static ByteBuffer getBase64Data(@Nonnull Resource resource) {
+  public static ByteBuffer getBase64Data(@NonNull Resource resource) {
     Base64 base64 = resource.getBase64();
 
     ByteBuffer retval = null;
@@ -100,7 +118,7 @@ public final class OscalUtils {
   }
 
   @Nullable
-  public static URI getResourceURI(@Nonnull Resource resource, @Nullable String preferredMediaType) {
+  public static URI getResourceURI(@NonNull Resource resource, @Nullable String preferredMediaType) {
     URI retval;
     if (hasBase64Data(resource)) {
       UUID uuid = resource.getUuid();
@@ -116,7 +134,7 @@ public final class OscalUtils {
   }
 
   @Nullable
-  public static Rlink findMatchingRLink(@Nonnull Resource resource, @Nullable String preferredMediaType) {
+  public static Rlink findMatchingRLink(@NonNull Resource resource, @Nullable String preferredMediaType) {
     // find a suitable rlink reference
     List<Rlink> rlinks = resource.getRlinks();
 
@@ -136,7 +154,7 @@ public final class OscalUtils {
   }
 
   @Nullable
-  public static InputSource newInputSource(@Nonnull Resource resource, @Nonnull EntityResolver resolver,
+  public static InputSource newInputSource(@NonNull Resource resource, @NonNull EntityResolver resolver,
       @Nullable String preferredMediaType) throws IOException {
     URI uri = getResourceURI(resource, null);
     if (uri == null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/HasOscalNamespace.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/HasOscalNamespace.java
@@ -42,13 +42,13 @@ import gov.nist.secauto.oscal.lib.model.AssessmentPart;
 import gov.nist.secauto.oscal.lib.model.ControlPart;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
 
 public final class HasOscalNamespace {
-  @NotNull
+  @Nonnull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
       .name("has-oscal-namespace")
       .argument(IArgument.newBuilder()
@@ -64,7 +64,7 @@ public final class HasOscalNamespace {
       .functionHandler(HasOscalNamespace::executeOneArg)
       .build();
 
-  @NotNull
+  @Nonnull
   static final IFunction SIGNATURE_TWO_ARGS = IFunction.builder()
       .name("has-oscal-namespace")
       .argument(IArgument.newBuilder()
@@ -89,9 +89,9 @@ public final class HasOscalNamespace {
     // disable construction
   }
 
-  @NotNull
-  public static ISequence<?> executeOneArg(@NotNull IFunction function,
-      @NotNull List<@NotNull ISequence<?>> arguments, @NotNull DynamicContext dynamicContext,
+  @Nonnull
+  public static ISequence<?> executeOneArg(@Nonnull IFunction function,
+      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
       INodeItem focus) {
     INodeItem node = focus;
     if (node == null) {
@@ -106,9 +106,9 @@ public final class HasOscalNamespace {
     return ISequence.of(hasNamespace(FunctionUtils.asType(node), namespaceArgs, dynamicContext));
   }
 
-  @NotNull
-  public static ISequence<?> executeTwoArg(@NotNull IFunction function,
-      @NotNull List<@NotNull ISequence<?>> arguments, @NotNull DynamicContext dynamicContext,
+  @Nonnull
+  public static ISequence<?> executeTwoArg(@Nonnull IFunction function,
+      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
       INodeItem focus) {
     ISequence<? extends IDefinitionNodeItem> nodeSequence = FunctionUtils.asType(arguments.get(0));
 
@@ -125,9 +125,9 @@ public final class HasOscalNamespace {
     return ISequence.of(hasNamespace(FunctionUtils.asType(node), namespaceArgs, dynamicContext));
   }
 
-  @NotNull
-  public static IBooleanItem hasNamespace(@NotNull IDefinitionNodeItem propOrPart,
-      @NotNull ISequence<? extends IStringItem> namespaces, @NotNull DynamicContext dynamicContext)
+  @Nonnull
+  public static IBooleanItem hasNamespace(@Nonnull IDefinitionNodeItem propOrPart,
+      @Nonnull ISequence<? extends IStringItem> namespaces, @Nonnull DynamicContext dynamicContext)
       throws MetapathException {
     Object propOrPartObject = propOrPart.getValue();
     if (propOrPartObject == null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/HasOscalNamespace.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/HasOscalNamespace.java
@@ -42,13 +42,13 @@ import gov.nist.secauto.oscal.lib.model.AssessmentPart;
 import gov.nist.secauto.oscal.lib.model.ControlPart;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import javax.annotation.Nonnull;
-
 import java.net.URI;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public final class HasOscalNamespace {
-  @Nonnull
+  @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
       .name("has-oscal-namespace")
       .argument(IArgument.newBuilder()
@@ -56,6 +56,7 @@ public final class HasOscalNamespace {
           .type(IStringItem.class)
           .oneOrMore()
           .build())
+      .allowUnboundedArity(true)
       .returnType(IBooleanItem.class)
       .focusDependent()
       .contextIndependent()
@@ -64,7 +65,7 @@ public final class HasOscalNamespace {
       .functionHandler(HasOscalNamespace::executeOneArg)
       .build();
 
-  @Nonnull
+  @NonNull
   static final IFunction SIGNATURE_TWO_ARGS = IFunction.builder()
       .name("has-oscal-namespace")
       .argument(IArgument.newBuilder()
@@ -77,6 +78,7 @@ public final class HasOscalNamespace {
           .type(IStringItem.class)
           .oneOrMore()
           .build())
+      .allowUnboundedArity(true)
       .focusIndependent()
       .contextIndependent()
       .deterministic()
@@ -89,45 +91,47 @@ public final class HasOscalNamespace {
     // disable construction
   }
 
-  @Nonnull
-  public static ISequence<?> executeOneArg(@Nonnull IFunction function,
-      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
+  @NonNull
+  public static ISequence<?> executeOneArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments, @NonNull DynamicContext dynamicContext,
       INodeItem focus) {
     INodeItem node = focus;
     if (node == null) {
-      return ISequence.empty();
+      return ISequence.empty(); // NOPMD - readability
     }
 
     ISequence<? extends IStringItem> namespaceArgs = FunctionUtils.asType(arguments.get(0));
     if (namespaceArgs.isEmpty()) {
-      return ISequence.empty();
+      return ISequence.empty(); // NOPMD - readability
     }
 
     return ISequence.of(hasNamespace(FunctionUtils.asType(node), namespaceArgs, dynamicContext));
   }
 
-  @Nonnull
-  public static ISequence<?> executeTwoArg(@Nonnull IFunction function,
-      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
+  @NonNull
+  public static ISequence<?> executeTwoArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments, @NonNull DynamicContext dynamicContext,
       INodeItem focus) {
     ISequence<? extends IDefinitionNodeItem> nodeSequence = FunctionUtils.asType(arguments.get(0));
 
     IItem node = FunctionUtils.getFirstItem(nodeSequence, true);
     if (node == null) {
-      return ISequence.empty();
+      return ISequence.empty(); // NOPMD - readability
     }
 
     ISequence<? extends IStringItem> namespaceArgs = FunctionUtils.asType(arguments.get(1));
     if (namespaceArgs.isEmpty()) {
-      return ISequence.empty();
+      return ISequence.empty(); // NOPMD - readability
     }
 
     return ISequence.of(hasNamespace(FunctionUtils.asType(node), namespaceArgs, dynamicContext));
   }
 
-  @Nonnull
-  public static IBooleanItem hasNamespace(@Nonnull IDefinitionNodeItem propOrPart,
-      @Nonnull ISequence<? extends IStringItem> namespaces, @Nonnull DynamicContext dynamicContext)
+  @NonNull
+  public static IBooleanItem hasNamespace( // NOPMD - item is boolean
+      @NonNull IDefinitionNodeItem propOrPart,
+      @NonNull ISequence<? extends IStringItem> namespaces,
+      @NonNull DynamicContext dynamicContext)
       throws MetapathException {
     Object propOrPartObject = propOrPart.getValue();
     if (propOrPartObject == null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/OscalFunctionLibrary.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/OscalFunctionLibrary.java
@@ -26,8 +26,12 @@
 
 package gov.nist.secauto.oscal.lib.metapath.function.library;
 
-import gov.nist.secauto.metaschema.model.common.metapath.function.FunctionLibrary;
+import com.google.auto.service.AutoService;
 
+import gov.nist.secauto.metaschema.model.common.metapath.function.FunctionLibrary;
+import gov.nist.secauto.metaschema.model.common.metapath.function.IFunctionLibrary;
+
+@AutoService(IFunctionLibrary.class)
 public class OscalFunctionLibrary
     extends FunctionLibrary {
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/OscalFunctionLibrary.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/OscalFunctionLibrary.java
@@ -26,10 +26,10 @@
 
 package gov.nist.secauto.oscal.lib.metapath.function.library;
 
-import gov.nist.secauto.metaschema.model.common.metapath.function.AbstractFunctionLibrary;
+import gov.nist.secauto.metaschema.model.common.metapath.function.FunctionLibrary;
 
 public class OscalFunctionLibrary
-    extends AbstractFunctionLibrary {
+    extends FunctionLibrary {
 
   public OscalFunctionLibrary() {
     registerFunction(ResolveProfile.SIGNATURE_NO_ARG);

--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
@@ -38,14 +38,14 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
 import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.List;
 
 public final class ResolveProfile {
 
-  @NotNull
+  @Nonnull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
       .name("resolve-profile")
       .returnType(INodeItem.class)
@@ -56,7 +56,7 @@ public final class ResolveProfile {
       .functionHandler(ResolveProfile::executeNoArg)
       .build();
 
-  @NotNull
+  @Nonnull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
       .name("resolve-profile")
       .argument(IArgument.newBuilder()
@@ -76,9 +76,9 @@ public final class ResolveProfile {
     // disable construction
   }
 
-  @NotNull
-  public static ISequence<?> executeNoArg(@NotNull IFunction function,
-      @NotNull List<@NotNull ISequence<?>> arguments, @NotNull DynamicContext dynamicContext,
+  @Nonnull
+  public static ISequence<?> executeNoArg(@Nonnull IFunction function,
+      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
       INodeItem focus) {
 
     INodeItem item = focus;
@@ -88,9 +88,9 @@ public final class ResolveProfile {
     return ISequence.of(resolveProfile(FunctionUtils.asType(item), dynamicContext));
   }
 
-  @NotNull
-  public static ISequence<?> executeOneArg(@NotNull IFunction function,
-      @NotNull List<@NotNull ISequence<?>> arguments, @NotNull DynamicContext dynamicContext,
+  @Nonnull
+  public static ISequence<?> executeOneArg(@Nonnull IFunction function,
+      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
       INodeItem focus) {
     ISequence<? extends IDocumentNodeItem> arg = FunctionUtils.asType(arguments.get(0));
 
@@ -102,9 +102,9 @@ public final class ResolveProfile {
     return ISequence.of(resolveProfile(FunctionUtils.asType(item), dynamicContext));
   }
 
-  @NotNull
-  public static IDocumentNodeItem resolveProfile(@NotNull IDocumentNodeItem profile,
-      @NotNull DynamicContext dynamicContext) {
+  @Nonnull
+  public static IDocumentNodeItem resolveProfile(@Nonnull IDocumentNodeItem profile,
+      @Nonnull DynamicContext dynamicContext) {
     Object profileObject = profile.getValue();
 
     IDocumentNodeItem retval;

--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
@@ -36,16 +36,17 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
 import gov.nist.secauto.oscal.lib.model.Catalog;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionException;
 import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.io.IOException;
 import java.util.List;
 
 public final class ResolveProfile {
 
-  @Nonnull
+  @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
       .name("resolve-profile")
       .returnType(INodeItem.class)
@@ -56,7 +57,7 @@ public final class ResolveProfile {
       .functionHandler(ResolveProfile::executeNoArg)
       .build();
 
-  @Nonnull
+  @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
       .name("resolve-profile")
       .argument(IArgument.newBuilder()
@@ -76,35 +77,35 @@ public final class ResolveProfile {
     // disable construction
   }
 
-  @Nonnull
-  public static ISequence<?> executeNoArg(@Nonnull IFunction function,
-      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
+  @NonNull
+  public static ISequence<?> executeNoArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments, @NonNull DynamicContext dynamicContext,
       INodeItem focus) {
 
     INodeItem item = focus;
     if (item == null) {
-      return ISequence.empty();
+      return ISequence.empty(); // NOPMD - readability
     }
     return ISequence.of(resolveProfile(FunctionUtils.asType(item), dynamicContext));
   }
 
-  @Nonnull
-  public static ISequence<?> executeOneArg(@Nonnull IFunction function,
-      @Nonnull List<@Nonnull ISequence<?>> arguments, @Nonnull DynamicContext dynamicContext,
+  @NonNull
+  public static ISequence<?> executeOneArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments, @NonNull DynamicContext dynamicContext,
       INodeItem focus) {
     ISequence<? extends IDocumentNodeItem> arg = FunctionUtils.asType(arguments.get(0));
 
     IItem item = FunctionUtils.getFirstItem(arg, true);
     if (item == null) {
-      return ISequence.empty();
+      return ISequence.empty(); // NOPMD - readability
     }
 
     return ISequence.of(resolveProfile(FunctionUtils.asType(item), dynamicContext));
   }
 
-  @Nonnull
-  public static IDocumentNodeItem resolveProfile(@Nonnull IDocumentNodeItem profile,
-      @Nonnull DynamicContext dynamicContext) {
+  @NonNull
+  public static IDocumentNodeItem resolveProfile(@NonNull IDocumentNodeItem profile,
+      @NonNull DynamicContext dynamicContext) {
     Object profileObject = profile.getValue();
 
     IDocumentNodeItem retval;
@@ -116,7 +117,7 @@ public final class ResolveProfile {
       resolver.setDynamicContext(dynamicContext);
       try {
         retval = resolver.resolve(profile);
-      } catch (IOException ex) {
+      } catch (IOException | ProfileResolutionException ex) {
         throw new MetapathException(String.format("Unable to resolve profile '%s'", profile.getBaseUri()), ex);
       }
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/AbstractOscalInstance.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/AbstractOscalInstance.java
@@ -29,14 +29,14 @@ package gov.nist.secauto.oscal.lib.model;
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 import gov.nist.secauto.oscal.lib.model.metadata.IBackMatter;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.UUID;
 
 public abstract class AbstractOscalInstance implements IOscalInstance {
 
   @Override
-  public Resource getResourceByUuid(@NotNull UUID uuid) {
+  public Resource getResourceByUuid(@Nonnull UUID uuid) {
     IBackMatter backMatter = getBackMatter();
 
     Resource retval = null;

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/AbstractOscalInstance.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/AbstractOscalInstance.java
@@ -29,14 +29,14 @@ package gov.nist.secauto.oscal.lib.model;
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 import gov.nist.secauto.oscal.lib.model.metadata.IBackMatter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.UUID;
 
 public abstract class AbstractOscalInstance implements IOscalInstance {
 
   @Override
-  public Resource getResourceByUuid(@Nonnull UUID uuid) {
+  public Resource getResourceByUuid(@NonNull UUID uuid) {
     IBackMatter backMatter = getBackMatter();
 
     Resource retval = null;

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/IOscalInstance.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/IOscalInstance.java
@@ -28,7 +28,7 @@ package gov.nist.secauto.oscal.lib.model;
 
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.UUID;
 
@@ -39,5 +39,5 @@ public interface IOscalInstance {
 
   BackMatter getBackMatter();
 
-  Resource getResourceByUuid(@Nonnull UUID id);
+  Resource getResourceByUuid(@NonNull UUID id);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/IOscalInstance.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/IOscalInstance.java
@@ -28,7 +28,7 @@ package gov.nist.secauto.oscal.lib.model;
 
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.UUID;
 
@@ -39,5 +39,5 @@ public interface IOscalInstance {
 
   BackMatter getBackMatter();
 
-  Resource getResourceByUuid(@NotNull UUID id);
+  Resource getResourceByUuid(@Nonnull UUID id);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractParameter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractParameter.java
@@ -37,8 +37,6 @@ import gov.nist.secauto.oscal.lib.model.ParameterSelection;
 import gov.nist.secauto.oscal.lib.model.Property;
 import gov.nist.secauto.oscal.lib.model.metadata.IProperty;
 
-import javax.annotation.Nonnull;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,10 +45,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public abstract class AbstractParameter implements IParameter {
 
   @Override
-  public Stream<@Nonnull String> getParameterReferences() {
+  public Stream<String> getParameterReferences() {
 
     // handle prop name="aggregates"
     Stream<String> aggregatesIds = CollectionUtil.listOrEmpty(getProps()).stream()
@@ -71,112 +71,112 @@ public abstract class AbstractParameter implements IParameter {
               .map(insert -> insert.getIdReference().toStringOrNull()));
     }
     @SuppressWarnings("null")
-    Stream<@Nonnull String> retval = Stream.concat(aggregatesIds, selectInsertIds)
+    Stream<String> retval = Stream.concat(aggregatesIds, selectInsertIds)
         .filter(Objects::nonNull)
         .distinct();
     return retval;
   }
 
-  @Nonnull
-  public static Builder builder(@Nonnull String id) {
+  @NonNull
+  public static Builder builder(@NonNull String id) {
     return new Builder(id);
   }
 
   public static class Builder {
-    @Nonnull
+    @NonNull
     private final String id;
 
-    private String clazz;
+    private String clazz; // NOPMD - intentional
     private final List<Property> props = new LinkedList<>();
     private final List<Link> links = new LinkedList<>();
-    private MarkupLine label;
-    private MarkupMultiline usage;
+    private MarkupLine label; // NOPMD - intentional
+    private MarkupMultiline usage; // NOPMD - intentional
     private final List<ParameterConstraint> constraints = new LinkedList<>();
     private final List<ParameterGuideline> guidelines = new LinkedList<>();
-    private List<String> values = new LinkedList<>();
+    private List<String> values = new LinkedList<>(); // NOPMD - intentional
     private ParameterSelection selection;
-    private MarkupMultiline remarks;
+    private MarkupMultiline remarks; // NOPMD - intentional
 
-    @SuppressWarnings("null")
-    public Builder(@Nonnull String id) {
-      this.id = Objects.requireNonNull(id, "id");
+    public Builder(@NonNull String id) {
+      this.id = Objects.requireNonNull(id);
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder clazz(@Nonnull String value) {
-      this.clazz = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder clazz(@NonNull String value) {
+      this.clazz = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder prop(@Nonnull Property value) {
-      this.props.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder prop(@NonNull Property value) {
+      this.props.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder link(@Nonnull Link value) {
-      this.links.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder link(@NonNull Link value) {
+      this.links.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder label(@Nonnull String markdown) {
-      return label(MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
+    @NonNull
+    public Builder label(@NonNull String markdown) {
+      return label(MarkupLine.fromMarkdown(Objects.requireNonNull(markdown)));
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder label(@Nonnull MarkupLine value) {
-      this.label = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder label(@NonNull MarkupLine value) {
+      this.label = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder usage(@Nonnull String markdown) {
-      return usage(MarkupMultiline.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
+    @NonNull
+    public Builder usage(@NonNull String markdown) {
+      return usage(MarkupMultiline.fromMarkdown(Objects.requireNonNull(markdown)));
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder usage(@Nonnull MarkupMultiline value) {
-      this.usage = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder usage(@NonNull MarkupMultiline value) {
+      this.usage = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder constraint(@Nonnull ParameterConstraint value) {
-      this.constraints.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder constraint(@NonNull ParameterConstraint value) {
+      this.constraints.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder guideline(@Nonnull ParameterGuideline value) {
-      this.guidelines.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder guideline(@NonNull ParameterGuideline value) {
+      this.guidelines.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder values(@Nonnull String... values) {
+    @NonNull
+    public Builder values(@NonNull String... values) {
       return values(Arrays.asList(values));
     }
 
-    @Nonnull
-    public Builder values(@Nonnull Collection<String> values) {
+    @NonNull
+    public Builder values(@NonNull Collection<String> values) {
       this.values = new ArrayList<>(values);
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder select(@Nonnull ParameterSelection value) {
-      this.selection = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder select(@NonNull ParameterSelection value) {
+      this.selection = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
+    @NonNull
+    public Builder remarks(@NonNull MarkupMultiline value) {
+      this.remarks = Objects.requireNonNull(value);
+      return this;
+    }
+
+    @NonNull
     public Parameter build() {
       Parameter retval = new Parameter();
       retval.setId(id);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractParameter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractParameter.java
@@ -37,7 +37,7 @@ import gov.nist.secauto.oscal.lib.model.ParameterSelection;
 import gov.nist.secauto.oscal.lib.model.Property;
 import gov.nist.secauto.oscal.lib.model.metadata.IProperty;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
 public abstract class AbstractParameter implements IParameter {
 
   @Override
-  public Stream<@NotNull String> getParameterReferences() {
+  public Stream<@Nonnull String> getParameterReferences() {
 
     // handle prop name="aggregates"
     Stream<String> aggregatesIds = CollectionUtil.listOrEmpty(getProps()).stream()
@@ -71,19 +71,19 @@ public abstract class AbstractParameter implements IParameter {
               .map(insert -> insert.getIdReference().toStringOrNull()));
     }
     @SuppressWarnings("null")
-    Stream<@NotNull String> retval = Stream.concat(aggregatesIds, selectInsertIds)
+    Stream<@Nonnull String> retval = Stream.concat(aggregatesIds, selectInsertIds)
         .filter(Objects::nonNull)
         .distinct();
     return retval;
   }
 
-  @NotNull
-  public static Builder builder(@NotNull String id) {
+  @Nonnull
+  public static Builder builder(@Nonnull String id) {
     return new Builder(id);
   }
 
   public static class Builder {
-    @NotNull
+    @Nonnull
     private final String id;
 
     private String clazz;
@@ -98,85 +98,85 @@ public abstract class AbstractParameter implements IParameter {
     private MarkupMultiline remarks;
 
     @SuppressWarnings("null")
-    public Builder(@NotNull String id) {
+    public Builder(@Nonnull String id) {
       this.id = Objects.requireNonNull(id, "id");
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder clazz(@NotNull String value) {
+    @Nonnull
+    public Builder clazz(@Nonnull String value) {
       this.clazz = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder prop(@NotNull Property value) {
+    @Nonnull
+    public Builder prop(@Nonnull Property value) {
       this.props.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder link(@NotNull Link value) {
+    @Nonnull
+    public Builder link(@Nonnull Link value) {
       this.links.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder label(@NotNull String markdown) {
+    @Nonnull
+    public Builder label(@Nonnull String markdown) {
       return label(MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder label(@NotNull MarkupLine value) {
+    @Nonnull
+    public Builder label(@Nonnull MarkupLine value) {
       this.label = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder usage(@NotNull String markdown) {
+    @Nonnull
+    public Builder usage(@Nonnull String markdown) {
       return usage(MarkupMultiline.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder usage(@NotNull MarkupMultiline value) {
+    @Nonnull
+    public Builder usage(@Nonnull MarkupMultiline value) {
       this.usage = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder constraint(@NotNull ParameterConstraint value) {
+    @Nonnull
+    public Builder constraint(@Nonnull ParameterConstraint value) {
       this.constraints.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder guideline(@NotNull ParameterGuideline value) {
+    @Nonnull
+    public Builder guideline(@Nonnull ParameterGuideline value) {
       this.guidelines.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder values(@NotNull String... values) {
+    @Nonnull
+    public Builder values(@Nonnull String... values) {
       return values(Arrays.asList(values));
     }
 
-    @NotNull
-    public Builder values(@NotNull Collection<String> values) {
+    @Nonnull
+    public Builder values(@Nonnull Collection<String> values) {
       this.values = new ArrayList<>(values);
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder select(@NotNull ParameterSelection value) {
+    @Nonnull
+    public Builder select(@Nonnull ParameterSelection value) {
       this.selection = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public Parameter build() {
       Parameter retval = new Parameter();
       retval.setId(id);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractPart.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractPart.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.oscal.lib.model.ControlPart;
 import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.net.URI;
 import java.util.LinkedList;
@@ -45,13 +45,12 @@ import java.util.stream.Stream;
 
 public abstract class AbstractPart implements IPart {
 
-  @SuppressWarnings({ "null" })
   @Override
-  @Nonnull
-  public Stream<InsertAnchorNode> getInserts(@Nonnull Predicate<InsertAnchorNode> filter) {
+  @NonNull
+  public Stream<InsertAnchorNode> getInserts(@NonNull Predicate<InsertAnchorNode> filter) {
     MarkupMultiline prose = getProse();
 
-    @Nonnull
+    @NonNull
     Stream<InsertAnchorNode> retval;
     if (prose == null) {
       retval = Stream.empty();
@@ -62,99 +61,93 @@ public abstract class AbstractPart implements IPart {
     return retval;
   }
 
-  public Stream<@Nonnull IPart> getPartsRecursively() {
+  public Stream<IPart> getPartsRecursively() {
     return Stream.concat(
         Stream.of(this),
         CollectionUtil.listOrEmpty(getParts()).stream()
             .flatMap(part -> part.getPartsRecursively()));
   }
 
-  @Nonnull
-  public static Builder builder(@Nonnull String name) {
+  @NonNull
+  public static Builder builder(@NonNull String name) {
     return new Builder(name);
   }
 
   public static class Builder {
-    private String id;
-    @Nonnull
+    private String id; // NOPMD - intentional
+    @NonNull
     private final String name;
-    private URI namespace;
-    private String clazz;
-    private MarkupMultiline prose;
-    private MarkupLine title;
+    private URI namespace; // NOPMD - intentional
+    private String clazz; // NOPMD - intentional
+    private MarkupMultiline prose; // NOPMD - intentional
+    private MarkupLine title; // NOPMD - intentional
     private final List<Property> props = new LinkedList<>();
     private final List<Link> links = new LinkedList<>();
     private final List<ControlPart> parts = new LinkedList<>();
 
-    @SuppressWarnings("null")
-    public Builder(@Nonnull String name) {
-      this.name = Objects.requireNonNull(name, "name");
+    public Builder(@NonNull String name) {
+      this.name = Objects.requireNonNull(name);
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder id(@Nonnull String value) {
-      this.id = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder id(@NonNull String value) { // NOPMD - intentional
+      this.id = Objects.requireNonNull(value);
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder namespace(@Nonnull URI value) {
-      this.namespace = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder namespace(@NonNull URI value) {
+      this.namespace = Objects.requireNonNull(value);
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder clazz(@Nonnull String value) {
-      this.clazz = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder clazz(@NonNull String value) {
+      this.clazz = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder title(@Nonnull String markdown) {
-      return title(MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
+    @NonNull
+    public Builder title(@NonNull String markdown) {
+      return title(MarkupLine.fromMarkdown(Objects.requireNonNull(markdown)));
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder title(@Nonnull MarkupLine value) {
-      this.title = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder title(@NonNull MarkupLine value) {
+      this.title = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder prose(@Nonnull String markdown) {
-      return prose(MarkupMultiline.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
+    @NonNull
+    public Builder prose(@NonNull String markdown) {
+      return prose(MarkupMultiline.fromMarkdown(Objects.requireNonNull(markdown)));
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder prose(@Nonnull MarkupMultiline value) {
-      this.prose = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder prose(@NonNull MarkupMultiline value) {
+      this.prose = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder prop(@Nonnull Property value) {
-      this.props.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder prop(@NonNull Property value) {
+      this.props.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder link(@Nonnull Link value) {
-      this.links.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder link(@NonNull Link value) {
+      this.links.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder part(@Nonnull ControlPart value) {
-      this.parts.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder part(@NonNull ControlPart value) {
+      this.parts.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public ControlPart build() {
       ControlPart retval = new ControlPart();
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractPart.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/AbstractPart.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.oscal.lib.model.ControlPart;
 import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.LinkedList;
@@ -47,11 +47,11 @@ public abstract class AbstractPart implements IPart {
 
   @SuppressWarnings({ "null" })
   @Override
-  @NotNull
-  public Stream<InsertAnchorNode> getInserts(@NotNull Predicate<InsertAnchorNode> filter) {
+  @Nonnull
+  public Stream<InsertAnchorNode> getInserts(@Nonnull Predicate<InsertAnchorNode> filter) {
     MarkupMultiline prose = getProse();
 
-    @NotNull
+    @Nonnull
     Stream<InsertAnchorNode> retval;
     if (prose == null) {
       retval = Stream.empty();
@@ -62,21 +62,21 @@ public abstract class AbstractPart implements IPart {
     return retval;
   }
 
-  public Stream<@NotNull IPart> getPartsRecursively() {
+  public Stream<@Nonnull IPart> getPartsRecursively() {
     return Stream.concat(
         Stream.of(this),
         CollectionUtil.listOrEmpty(getParts()).stream()
             .flatMap(part -> part.getPartsRecursively()));
   }
 
-  @NotNull
-  public static Builder builder(@NotNull String name) {
+  @Nonnull
+  public static Builder builder(@Nonnull String name) {
     return new Builder(name);
   }
 
   public static class Builder {
     private String id;
-    @NotNull
+    @Nonnull
     private final String name;
     private URI namespace;
     private String clazz;
@@ -87,74 +87,74 @@ public abstract class AbstractPart implements IPart {
     private final List<ControlPart> parts = new LinkedList<>();
 
     @SuppressWarnings("null")
-    public Builder(@NotNull String name) {
+    public Builder(@Nonnull String name) {
       this.name = Objects.requireNonNull(name, "name");
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder id(@NotNull String value) {
+    @Nonnull
+    public Builder id(@Nonnull String value) {
       this.id = Objects.requireNonNull(value, "value");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder namespace(@NotNull URI value) {
+    @Nonnull
+    public Builder namespace(@Nonnull URI value) {
       this.namespace = Objects.requireNonNull(value, "value");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder clazz(@NotNull String value) {
+    @Nonnull
+    public Builder clazz(@Nonnull String value) {
       this.clazz = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder title(@NotNull String markdown) {
+    @Nonnull
+    public Builder title(@Nonnull String markdown) {
       return title(MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder title(@NotNull MarkupLine value) {
+    @Nonnull
+    public Builder title(@Nonnull MarkupLine value) {
       this.title = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder prose(@NotNull String markdown) {
+    @Nonnull
+    public Builder prose(@Nonnull String markdown) {
       return prose(MarkupMultiline.fromMarkdown(Objects.requireNonNull(markdown, "markdown")));
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder prose(@NotNull MarkupMultiline value) {
+    @Nonnull
+    public Builder prose(@Nonnull MarkupMultiline value) {
       this.prose = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder prop(@NotNull Property value) {
+    @Nonnull
+    public Builder prop(@Nonnull Property value) {
       this.props.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder link(@NotNull Link value) {
+    @Nonnull
+    public Builder link(@Nonnull Link value) {
       this.links.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder part(@NotNull ControlPart value) {
+    @Nonnull
+    public Builder part(@Nonnull ControlPart value) {
       this.parts.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public ControlPart build() {
       ControlPart retval = new ControlPart();
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/IParameter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/IParameter.java
@@ -29,7 +29,7 @@ package gov.nist.secauto.oscal.lib.model.control;
 import gov.nist.secauto.oscal.lib.model.ParameterSelection;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -39,5 +39,5 @@ public interface IParameter {
 
   ParameterSelection getSelect();
 
-  Stream<@NotNull String> getParameterReferences();
+  Stream<@Nonnull String> getParameterReferences();
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/IParameter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/IParameter.java
@@ -29,8 +29,6 @@ package gov.nist.secauto.oscal.lib.model.control;
 import gov.nist.secauto.oscal.lib.model.ParameterSelection;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -39,5 +37,5 @@ public interface IParameter {
 
   ParameterSelection getSelect();
 
-  Stream<@Nonnull String> getParameterReferences();
+  Stream<String> getParameterReferences();
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/IPart.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/IPart.java
@@ -30,7 +30,7 @@ import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupMultiline;
 import gov.nist.secauto.metaschema.model.common.datatype.markup.flexmark.InsertAnchorNode;
 import gov.nist.secauto.oscal.lib.model.ControlPart;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -41,6 +41,6 @@ public interface IPart {
 
   List<ControlPart> getParts();
 
-  @Nonnull
-  Stream<InsertAnchorNode> getInserts(@Nonnull Predicate<InsertAnchorNode> filter);
+  @NonNull
+  Stream<InsertAnchorNode> getInserts(@NonNull Predicate<InsertAnchorNode> filter);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/IPart.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/IPart.java
@@ -30,7 +30,7 @@ import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupMultiline;
 import gov.nist.secauto.metaschema.model.common.datatype.markup.flexmark.InsertAnchorNode;
 import gov.nist.secauto.oscal.lib.model.ControlPart;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -41,6 +41,6 @@ public interface IPart {
 
   List<ControlPart> getParts();
 
-  @NotNull
-  Stream<InsertAnchorNode> getInserts(@NotNull Predicate<InsertAnchorNode> filter);
+  @Nonnull
+  Stream<InsertAnchorNode> getInserts(@Nonnull Predicate<InsertAnchorNode> filter);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalog.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalog.java
@@ -30,7 +30,7 @@ import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.model.AbstractOscalInstance;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.stream.Stream;
 
@@ -39,9 +39,9 @@ public abstract class AbstractCatalog
     implements ICatalog {
 
   @SuppressWarnings("null")
-  @NotNull
+  @Nonnull
   @Override
-  public Stream<@NotNull String> getReferencedParameterIds() {
+  public Stream<@Nonnull String> getReferencedParameterIds() {
     // get parameters referenced by the control's parameters
     return CollectionUtil.listOrEmpty(getParams()).stream()
         .flatMap(ObjectUtils::filterNull)

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalog.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalog.java
@@ -30,7 +30,7 @@ import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.model.AbstractOscalInstance;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.stream.Stream;
 
@@ -38,10 +38,9 @@ public abstract class AbstractCatalog
     extends AbstractOscalInstance
     implements ICatalog {
 
-  @SuppressWarnings("null")
-  @Nonnull
+  @NonNull
   @Override
-  public Stream<@Nonnull String> getReferencedParameterIds() {
+  public Stream<String> getReferencedParameterIds() {
     // get parameters referenced by the control's parameters
     return CollectionUtil.listOrEmpty(getParams()).stream()
         .flatMap(ObjectUtils::filterNull)

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogGroup.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogGroup.java
@@ -36,7 +36,7 @@ import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -47,13 +47,12 @@ import java.util.stream.Stream;
 public abstract class AbstractCatalogGroup
     implements ICatalogGroup, IGroupContainer {
 
-  @SuppressWarnings("null")
-  @Nonnull
+  @NonNull
   @Override
-  public Stream<@Nonnull String> getReferencedParameterIds() {
+  public Stream<String> getReferencedParameterIds() {
 
     // get parameters referenced by the group's parts
-    Stream<@Nonnull String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
+    Stream<String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
         // Get the full part hierarchy
         .flatMap(part -> Stream.concat(Stream.of(part), part.getPartsRecursively()))
         // Get the inserts for each part
@@ -63,7 +62,7 @@ public abstract class AbstractCatalogGroup
         .flatMap(ObjectUtils::filterNull);
 
     // get parameters referenced by the control's parameters
-    Stream<@Nonnull String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
+    Stream<String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
         .flatMap(ObjectUtils::filterNull)
         .flatMap(param -> param.getParameterReferences());
 
@@ -71,13 +70,13 @@ public abstract class AbstractCatalogGroup
         .distinct();
   }
 
-  @Nonnull
-  public static Builder builder(@Nonnull String id) {
+  @NonNull
+  public static Builder builder(@NonNull String id) {
     return new Builder(id);
   }
 
   public static class Builder {
-    @Nonnull
+    @NonNull
     private final String id;
 
     private String clazz;
@@ -89,68 +88,66 @@ public abstract class AbstractCatalogGroup
     private final List<CatalogGroup> groups = new LinkedList<>();
     private final List<Control> controls = new LinkedList<>();
 
-    @SuppressWarnings("null")
-    public Builder(@Nonnull String id) {
+    public Builder(@NonNull String id) {
       this.id = Objects.requireNonNull(id, "id");
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder clazz(@Nonnull String value) {
+    @NonNull
+    public Builder clazz(@NonNull String value) {
       this.clazz = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @Nonnull
-    public Builder title(@Nonnull String markdown) {
+    @NonNull
+    public Builder title(@NonNull String markdown) {
       this.title = MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown"));
       return this;
     }
 
     @SuppressWarnings("null")
-    @Nonnull
-    public Builder title(@Nonnull MarkupLine value) {
+    @NonNull
+    public Builder title(@NonNull MarkupLine value) {
       this.title = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @Nonnull
-    public Builder param(@Nonnull Parameter value) {
+    @NonNull
+    public Builder param(@NonNull Parameter value) {
       this.params.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @Nonnull
-    public Builder prop(@Nonnull Property value) {
+    @NonNull
+    public Builder prop(@NonNull Property value) {
       this.props.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @Nonnull
-    public Builder link(@Nonnull Link value) {
+    @NonNull
+    public Builder link(@NonNull Link value) {
       this.links.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @Nonnull
-    public Builder part(@Nonnull ControlPart value) {
+    @NonNull
+    public Builder part(@NonNull ControlPart value) {
       this.parts.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @Nonnull
-    public Builder group(@Nonnull CatalogGroup value) {
+    @NonNull
+    public Builder group(@NonNull CatalogGroup value) {
       this.groups.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @Nonnull
-    public Builder control(@Nonnull Control value) {
+    @NonNull
+    public Builder control(@NonNull Control value) {
       this.controls.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public CatalogGroup build() {
       CatalogGroup retval = new CatalogGroup();
       retval.setId(id);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogGroup.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogGroup.java
@@ -36,7 +36,7 @@ import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -48,12 +48,12 @@ public abstract class AbstractCatalogGroup
     implements ICatalogGroup, IGroupContainer {
 
   @SuppressWarnings("null")
-  @NotNull
+  @Nonnull
   @Override
-  public Stream<@NotNull String> getReferencedParameterIds() {
+  public Stream<@Nonnull String> getReferencedParameterIds() {
 
     // get parameters referenced by the group's parts
-    Stream<@NotNull String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
+    Stream<@Nonnull String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
         // Get the full part hierarchy
         .flatMap(part -> Stream.concat(Stream.of(part), part.getPartsRecursively()))
         // Get the inserts for each part
@@ -63,7 +63,7 @@ public abstract class AbstractCatalogGroup
         .flatMap(ObjectUtils::filterNull);
 
     // get parameters referenced by the control's parameters
-    Stream<@NotNull String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
+    Stream<@Nonnull String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
         .flatMap(ObjectUtils::filterNull)
         .flatMap(param -> param.getParameterReferences());
 
@@ -71,13 +71,13 @@ public abstract class AbstractCatalogGroup
         .distinct();
   }
 
-  @NotNull
-  public static Builder builder(@NotNull String id) {
+  @Nonnull
+  public static Builder builder(@Nonnull String id) {
     return new Builder(id);
   }
 
   public static class Builder {
-    @NotNull
+    @Nonnull
     private final String id;
 
     private String clazz;
@@ -90,67 +90,67 @@ public abstract class AbstractCatalogGroup
     private final List<Control> controls = new LinkedList<>();
 
     @SuppressWarnings("null")
-    public Builder(@NotNull String id) {
+    public Builder(@Nonnull String id) {
       this.id = Objects.requireNonNull(id, "id");
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder clazz(@NotNull String value) {
+    @Nonnull
+    public Builder clazz(@Nonnull String value) {
       this.clazz = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder title(@NotNull String markdown) {
+    @Nonnull
+    public Builder title(@Nonnull String markdown) {
       this.title = MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown"));
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder title(@NotNull MarkupLine value) {
+    @Nonnull
+    public Builder title(@Nonnull MarkupLine value) {
       this.title = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder param(@NotNull Parameter value) {
+    @Nonnull
+    public Builder param(@Nonnull Parameter value) {
       this.params.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder prop(@NotNull Property value) {
+    @Nonnull
+    public Builder prop(@Nonnull Property value) {
       this.props.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder link(@NotNull Link value) {
+    @Nonnull
+    public Builder link(@Nonnull Link value) {
       this.links.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder part(@NotNull ControlPart value) {
+    @Nonnull
+    public Builder part(@Nonnull ControlPart value) {
       this.parts.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder group(@NotNull CatalogGroup value) {
+    @Nonnull
+    public Builder group(@Nonnull CatalogGroup value) {
       this.groups.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder control(@NotNull Control value) {
+    @Nonnull
+    public Builder control(@Nonnull Control value) {
       this.controls.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public CatalogGroup build() {
       CatalogGroup retval = new CatalogGroup();
       retval.setId(id);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogVisitor.java
@@ -31,7 +31,7 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Objects;
 
@@ -62,7 +62,7 @@ public abstract class AbstractCatalogVisitor<RESULT, CONTEXT> implements ICatalo
 
   @SuppressWarnings("null")
   @Override
-  public RESULT visitGroup(@NotNull CatalogGroup group, CONTEXT context) {
+  public RESULT visitGroup(@Nonnull CatalogGroup group, CONTEXT context) {
     RESULT result = group.getGroups().stream()
         .filter(Objects::nonNull)
         .map(childGroup -> visitGroup(childGroup, context))

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractCatalogVisitor.java
@@ -26,12 +26,13 @@
 
 package gov.nist.secauto.oscal.lib.model.control.catalog;
 
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Objects;
 
@@ -43,48 +44,45 @@ public abstract class AbstractCatalogVisitor<RESULT, CONTEXT> implements ICatalo
     return current;
   }
 
-  @SuppressWarnings("null")
   @Override
   public RESULT visitCatalog(Catalog catalog, CONTEXT context) {
-    RESULT result = catalog.getGroups().stream()
+    RESULT result = CollectionUtil.listOrEmpty(catalog.getGroups()).stream()
         .filter(Objects::nonNull)
         .map(childGroup -> visitGroup(childGroup, context))
         .reduce(defaultResult(), (previous, current) -> aggregateResult(previous, current));
-    result = catalog.getControls().stream()
+    result = CollectionUtil.listOrEmpty(catalog.getControls()).stream()
         .filter(Objects::nonNull)
         .map(childControl -> visitControl(childControl, context))
         .reduce(result, (previous, current) -> aggregateResult(previous, current));
-    return catalog.getParams().stream()
+    return CollectionUtil.listOrEmpty(catalog.getParams()).stream()
         .filter(Objects::nonNull)
         .map(childParameter -> visitParameter(childParameter, context))
         .reduce(result, (previous, current) -> aggregateResult(previous, current));
   }
 
-  @SuppressWarnings("null")
   @Override
-  public RESULT visitGroup(@Nonnull CatalogGroup group, CONTEXT context) {
-    RESULT result = group.getGroups().stream()
+  public RESULT visitGroup(@NonNull CatalogGroup group, CONTEXT context) {
+    RESULT result = CollectionUtil.listOrEmpty(group.getGroups()).stream()
         .filter(Objects::nonNull)
         .map(childGroup -> visitGroup(childGroup, context))
         .reduce(defaultResult(), (previous, current) -> aggregateResult(previous, current));
-    result = group.getControls().stream()
+    result = CollectionUtil.listOrEmpty(group.getControls()).stream()
         .filter(Objects::nonNull)
         .map(childControl -> visitControl(childControl, context))
         .reduce(result, (previous, current) -> aggregateResult(previous, current));
-    return group.getParams().stream()
+    return CollectionUtil.listOrEmpty(group.getParams()).stream()
         .filter(Objects::nonNull)
         .map(childParameter -> visitParameter(childParameter, context))
         .reduce(result, (previous, current) -> aggregateResult(previous, current));
   }
 
-  @SuppressWarnings("null")
   @Override
   public RESULT visitControl(Control control, CONTEXT context) {
-    RESULT result = control.getControls().stream()
+    RESULT result = CollectionUtil.listOrEmpty(control.getControls()).stream()
         .filter(Objects::nonNull)
         .map(childControl -> visitControl(childControl, context))
         .reduce(defaultResult(), (previous, current) -> aggregateResult(previous, current));
-    return control.getParams().stream()
+    return CollectionUtil.listOrEmpty(control.getParams()).stream()
         .filter(Objects::nonNull)
         .map(childParameter -> visitParameter(childParameter, context))
         .reduce(result, (previous, current) -> aggregateResult(previous, current));

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractControl.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractControl.java
@@ -36,7 +36,7 @@ import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -71,12 +71,12 @@ public abstract class AbstractControl
   }
 
   @SuppressWarnings("null")
-  @NotNull
+  @Nonnull
   @Override
-  public Stream<@NotNull String> getReferencedParameterIds() {
+  public Stream<@Nonnull String> getReferencedParameterIds() {
 
     // get parameters referenced by the group's parts
-    Stream<@NotNull String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
+    Stream<@Nonnull String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
         // Get the full part hierarchy
         .flatMap(part -> Stream.concat(Stream.of(part), part.getPartsRecursively()))
         // Get the inserts for each part
@@ -86,7 +86,7 @@ public abstract class AbstractControl
         .flatMap(ObjectUtils::filterNull);
 
     // get parameters referenced by the control's parameters
-    Stream<@NotNull String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
+    Stream<@Nonnull String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
         .flatMap(ObjectUtils::filterNull)
         .flatMap(param -> param.getParameterReferences());
 
@@ -94,13 +94,13 @@ public abstract class AbstractControl
         .distinct();
   }
 
-  @NotNull
-  public static Builder builder(@NotNull String id) {
+  @Nonnull
+  public static Builder builder(@Nonnull String id) {
     return new Builder(id);
   }
 
   public static class Builder {
-    @NotNull
+    @Nonnull
     private final String id;
 
     private String clazz;
@@ -112,62 +112,62 @@ public abstract class AbstractControl
     private final List<Control> controls = new LinkedList<>();
 
     @SuppressWarnings("null")
-    public Builder(@NotNull String id) {
+    public Builder(@Nonnull String id) {
       this.id = Objects.requireNonNull(id, "id");
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder clazz(@NotNull String value) {
+    @Nonnull
+    public Builder clazz(@Nonnull String value) {
       this.clazz = Objects.requireNonNull(value, "value");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder title(@NotNull String markdown) {
+    @Nonnull
+    public Builder title(@Nonnull String markdown) {
       this.title = MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown"));
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder title(@NotNull MarkupLine value) {
+    @Nonnull
+    public Builder title(@Nonnull MarkupLine value) {
       this.title = Objects.requireNonNull(value, "value");
       return this;
     }
 
-    @NotNull
-    public Builder param(@NotNull Parameter value) {
+    @Nonnull
+    public Builder param(@Nonnull Parameter value) {
       this.params.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder prop(@NotNull Property value) {
+    @Nonnull
+    public Builder prop(@Nonnull Property value) {
       this.props.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder link(@NotNull Link value) {
+    @Nonnull
+    public Builder link(@Nonnull Link value) {
       this.links.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder part(@NotNull ControlPart value) {
+    @Nonnull
+    public Builder part(@Nonnull ControlPart value) {
       this.parts.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
-    public Builder control(@NotNull Control value) {
+    @Nonnull
+    public Builder control(@Nonnull Control value) {
       this.controls.add(Objects.requireNonNull(value, "value"));
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public Control build() {
       Control retval = new Control();
       retval.setId(id);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractControl.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/AbstractControl.java
@@ -36,7 +36,7 @@ import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -70,13 +70,12 @@ public abstract class AbstractControl
     }
   }
 
-  @SuppressWarnings("null")
-  @Nonnull
+  @NonNull
   @Override
-  public Stream<@Nonnull String> getReferencedParameterIds() {
+  public Stream<String> getReferencedParameterIds() {
 
     // get parameters referenced by the group's parts
-    Stream<@Nonnull String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
+    Stream<String> insertIds = CollectionUtil.listOrEmpty(getParts()).stream()
         // Get the full part hierarchy
         .flatMap(part -> Stream.concat(Stream.of(part), part.getPartsRecursively()))
         // Get the inserts for each part
@@ -86,7 +85,7 @@ public abstract class AbstractControl
         .flatMap(ObjectUtils::filterNull);
 
     // get parameters referenced by the control's parameters
-    Stream<@Nonnull String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
+    Stream<String> parameterIds = CollectionUtil.listOrEmpty(getParams()).stream()
         .flatMap(ObjectUtils::filterNull)
         .flatMap(param -> param.getParameterReferences());
 
@@ -94,80 +93,76 @@ public abstract class AbstractControl
         .distinct();
   }
 
-  @Nonnull
-  public static Builder builder(@Nonnull String id) {
+  @NonNull
+  public static Builder builder(@NonNull String id) {
     return new Builder(id);
   }
 
   public static class Builder {
-    @Nonnull
+    @NonNull
     private final String id;
 
-    private String clazz;
-    private MarkupLine title;
+    private String clazz; // NOPMD - intentional
+    private MarkupLine title; // NOPMD - intentional
     private final List<Parameter> params = new LinkedList<>();
     private final List<Property> props = new LinkedList<>();
     private final List<Link> links = new LinkedList<>();
     private final List<ControlPart> parts = new LinkedList<>();
     private final List<Control> controls = new LinkedList<>();
 
-    @SuppressWarnings("null")
-    public Builder(@Nonnull String id) {
+    public Builder(@NonNull String id) {
       this.id = Objects.requireNonNull(id, "id");
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder clazz(@Nonnull String value) {
-      this.clazz = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder clazz(@NonNull String value) {
+      this.clazz = Objects.requireNonNull(value);
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder title(@Nonnull String markdown) {
-      this.title = MarkupLine.fromMarkdown(Objects.requireNonNull(markdown, "markdown"));
+    @NonNull
+    public Builder title(@NonNull String markdown) {
+      this.title = MarkupLine.fromMarkdown(Objects.requireNonNull(markdown));
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder title(@Nonnull MarkupLine value) {
-      this.title = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder title(@NonNull MarkupLine value) {
+      this.title = Objects.requireNonNull(value);
       return this;
     }
 
-    @Nonnull
-    public Builder param(@Nonnull Parameter value) {
-      this.params.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder param(@NonNull Parameter value) {
+      this.params.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder prop(@Nonnull Property value) {
-      this.props.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder prop(@NonNull Property value) {
+      this.props.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder link(@Nonnull Link value) {
-      this.links.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder link(@NonNull Link value) {
+      this.links.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder part(@Nonnull ControlPart value) {
-      this.parts.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder part(@NonNull ControlPart value) {
+      this.parts.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
-    public Builder control(@Nonnull Control value) {
-      this.controls.add(Objects.requireNonNull(value, "value"));
+    @NonNull
+    public Builder control(@NonNull Control value) {
+      this.controls.add(Objects.requireNonNull(value));
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public Control build() {
       Control retval = new Control();
       retval.setId(id);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/ICatalog.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/ICatalog.java
@@ -27,5 +27,5 @@
 package gov.nist.secauto.oscal.lib.model.control.catalog;
 
 public interface ICatalog extends IGroupContainer {
-
+  // no additional methods
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/ICatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/ICatalogVisitor.java
@@ -31,14 +31,14 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface ICatalogVisitor<RESULT, CONTEXT> {
-  RESULT visitCatalog(@Nonnull Catalog catalog, CONTEXT context);
+  RESULT visitCatalog(@NonNull Catalog catalog, CONTEXT context);
 
-  RESULT visitGroup(@Nonnull CatalogGroup group, CONTEXT context);
+  RESULT visitGroup(@NonNull CatalogGroup group, CONTEXT context);
 
-  RESULT visitControl(@Nonnull Control control, CONTEXT context);
+  RESULT visitControl(@NonNull Control control, CONTEXT context);
 
-  RESULT visitParameter(@Nonnull Parameter parameter, CONTEXT context);
+  RESULT visitParameter(@NonNull Parameter parameter, CONTEXT context);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/ICatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/ICatalogVisitor.java
@@ -31,14 +31,14 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public interface ICatalogVisitor<RESULT, CONTEXT> {
-  RESULT visitCatalog(@NotNull Catalog catalog, CONTEXT context);
+  RESULT visitCatalog(@Nonnull Catalog catalog, CONTEXT context);
 
-  RESULT visitGroup(@NotNull CatalogGroup group, CONTEXT context);
+  RESULT visitGroup(@Nonnull CatalogGroup group, CONTEXT context);
 
-  RESULT visitControl(@NotNull Control control, CONTEXT context);
+  RESULT visitControl(@Nonnull Control control, CONTEXT context);
 
-  RESULT visitParameter(@NotNull Parameter parameter, CONTEXT context);
+  RESULT visitParameter(@Nonnull Parameter parameter, CONTEXT context);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IControlContainer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IControlContainer.java
@@ -29,14 +29,14 @@ package gov.nist.secauto.oscal.lib.model.control.catalog;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.List;
 import java.util.stream.Stream;
 
 public interface IControlContainer {
 
-  List<@Nonnull Control> getControls();
+  List<Control> getControls();
 
   /**
    * Add a new {@link Control} item to the end of the underlying collection.
@@ -45,7 +45,7 @@ public interface IControlContainer {
    *          the item to add
    * @return {@code true}
    */
-  boolean addControl(@Nonnull Control item);
+  boolean addControl(@NonNull Control item);
 
   /**
    * Remove the first matching {@link Control} item from the underlying collection.
@@ -54,9 +54,9 @@ public interface IControlContainer {
    *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
-  boolean removeControl(@Nonnull Control item);
+  boolean removeControl(@NonNull Control item);
 
-  List<@Nonnull Parameter> getParams();
+  List<Parameter> getParams();
 
   /**
    * Add a new {@link Parameter} item to the underlying collection.
@@ -65,7 +65,7 @@ public interface IControlContainer {
    *          the item to add
    * @return {@code true}
    */
-  boolean addParam(@Nonnull Parameter item);
+  boolean addParam(@NonNull Parameter item);
 
   /**
    * Remove the first matching {@link Parameter} item from the underlying collection.
@@ -74,12 +74,12 @@ public interface IControlContainer {
    *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
-  boolean removeParam(@Nonnull Parameter item);
+  boolean removeParam(@NonNull Parameter item);
 
   /**
    * Get the parameter identifiers referenced in the object's context, but not by their child objects.
    * 
    * @return a stream of identifiers
    */
-  Stream<@Nonnull String> getReferencedParameterIds();
+  Stream<String> getReferencedParameterIds();
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IControlContainer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IControlContainer.java
@@ -29,14 +29,14 @@ package gov.nist.secauto.oscal.lib.model.control.catalog;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.stream.Stream;
 
 public interface IControlContainer {
 
-  List<@NotNull Control> getControls();
+  List<@Nonnull Control> getControls();
 
   /**
    * Add a new {@link Control} item to the end of the underlying collection.
@@ -45,7 +45,7 @@ public interface IControlContainer {
    *          the item to add
    * @return {@code true}
    */
-  boolean addControl(@NotNull Control item);
+  boolean addControl(@Nonnull Control item);
 
   /**
    * Remove the first matching {@link Control} item from the underlying collection.
@@ -54,9 +54,9 @@ public interface IControlContainer {
    *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
-  boolean removeControl(@NotNull Control item);
+  boolean removeControl(@Nonnull Control item);
 
-  List<@NotNull Parameter> getParams();
+  List<@Nonnull Parameter> getParams();
 
   /**
    * Add a new {@link Parameter} item to the underlying collection.
@@ -65,7 +65,7 @@ public interface IControlContainer {
    *          the item to add
    * @return {@code true}
    */
-  boolean addParam(@NotNull Parameter item);
+  boolean addParam(@Nonnull Parameter item);
 
   /**
    * Remove the first matching {@link Parameter} item from the underlying collection.
@@ -74,12 +74,12 @@ public interface IControlContainer {
    *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
-  boolean removeParam(@NotNull Parameter item);
+  boolean removeParam(@Nonnull Parameter item);
 
   /**
    * Get the parameter identifiers referenced in the object's context, but not by their child objects.
    * 
    * @return a stream of identifiers
    */
-  Stream<@NotNull String> getReferencedParameterIds();
+  Stream<@Nonnull String> getReferencedParameterIds();
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IGroupContainer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IGroupContainer.java
@@ -28,13 +28,13 @@ package gov.nist.secauto.oscal.lib.model.control.catalog;
 
 import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 
 public interface IGroupContainer extends IControlContainer {
 
-  List<@NotNull CatalogGroup> getGroups();
+  List<@Nonnull CatalogGroup> getGroups();
 
   /**
    * Add a new {@link CatalogGroup} item to the end of the underlying collection.
@@ -43,7 +43,7 @@ public interface IGroupContainer extends IControlContainer {
    *          the item to add
    * @return {@code true}
    */
-  boolean addGroup(@NotNull CatalogGroup item);
+  boolean addGroup(@Nonnull CatalogGroup item);
 
   /**
    * Remove the first matching {@link CatalogGroup} item from the underlying collection.
@@ -52,5 +52,5 @@ public interface IGroupContainer extends IControlContainer {
    *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
-  boolean removeGroup(@NotNull CatalogGroup item);
+  boolean removeGroup(@Nonnull CatalogGroup item);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IGroupContainer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IGroupContainer.java
@@ -28,13 +28,13 @@ package gov.nist.secauto.oscal.lib.model.control.catalog;
 
 import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface IGroupContainer extends IControlContainer {
 
-  List<@Nonnull CatalogGroup> getGroups();
+  List<CatalogGroup> getGroups();
 
   /**
    * Add a new {@link CatalogGroup} item to the end of the underlying collection.
@@ -43,7 +43,7 @@ public interface IGroupContainer extends IControlContainer {
    *          the item to add
    * @return {@code true}
    */
-  boolean addGroup(@Nonnull CatalogGroup item);
+  boolean addGroup(@NonNull CatalogGroup item);
 
   /**
    * Remove the first matching {@link CatalogGroup} item from the underlying collection.
@@ -52,5 +52,5 @@ public interface IGroupContainer extends IControlContainer {
    *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
-  boolean removeGroup(@Nonnull CatalogGroup item);
+  boolean removeGroup(@NonNull CatalogGroup item);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/profile/AbstractProfileSelectControlById.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/profile/AbstractProfileSelectControlById.java
@@ -29,7 +29,7 @@ package gov.nist.secauto.oscal.lib.model.control.profile;
 import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById;
 import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById.Matching;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractProfileSelectControlById implements IProfileSelectControlById {
   // TODO: move implementation from profile resolver selection code here
 
-  @Nonnull
+  @NonNull
   public static Builder builder() {
     return new Builder();
   }
@@ -51,31 +51,31 @@ public abstract class AbstractProfileSelectControlById implements IProfileSelect
     private final List<String> withIds = new LinkedList<>();
     private final List<Pattern> matching = new LinkedList<>();
 
-    @Nonnull
+    @NonNull
     public Builder withChildControls(boolean value) {
       this.withChildControls = value;
       return this;
     }
 
-    @Nonnull
-    public Builder withId(@Nonnull String id) {
+    @NonNull
+    public Builder withId(@NonNull String id) {
       withIds.add(id);
       return this;
     }
 
-    @Nonnull
-    public Builder withIds(@Nonnull Collection<String> ids) {
+    @NonNull
+    public Builder withIds(@NonNull Collection<String> ids) {
       withIds.addAll(ids);
       return this;
     }
 
-    @Nonnull
-    public Builder matching(@Nonnull Pattern pattern) {
+    @NonNull
+    public Builder matching(@NonNull Pattern pattern) {
       matching.add(pattern);
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public ProfileSelectControlById build() {
       ProfileSelectControlById retval = new ProfileSelectControlById();
       retval.setWithChildControls(withChildControls ? "yes" : "no");

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/profile/AbstractProfileSelectControlById.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/profile/AbstractProfileSelectControlById.java
@@ -29,7 +29,7 @@ package gov.nist.secauto.oscal.lib.model.control.profile;
 import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById;
 import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById.Matching;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractProfileSelectControlById implements IProfileSelectControlById {
   // TODO: move implementation from profile resolver selection code here
 
-  @NotNull
+  @Nonnull
   public static Builder builder() {
     return new Builder();
   }
@@ -51,31 +51,31 @@ public abstract class AbstractProfileSelectControlById implements IProfileSelect
     private final List<String> withIds = new LinkedList<>();
     private final List<Pattern> matching = new LinkedList<>();
 
-    @NotNull
+    @Nonnull
     public Builder withChildControls(boolean value) {
       this.withChildControls = value;
       return this;
     }
 
-    @NotNull
-    public Builder withId(@NotNull String id) {
+    @Nonnull
+    public Builder withId(@Nonnull String id) {
       withIds.add(id);
       return this;
     }
 
-    @NotNull
-    public Builder withIds(@NotNull Collection<String> ids) {
+    @Nonnull
+    public Builder withIds(@Nonnull Collection<String> ids) {
       withIds.addAll(ids);
       return this;
     }
 
-    @NotNull
-    public Builder matching(@NotNull Pattern pattern) {
+    @Nonnull
+    public Builder matching(@Nonnull Pattern pattern) {
       matching.add(pattern);
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public ProfileSelectControlById build() {
       ProfileSelectControlById retval = new ProfileSelectControlById();
       retval.setWithChildControls(withChildControls ? "yes" : "no");

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractBackMatter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractBackMatter.java
@@ -28,7 +28,7 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.UUID;
@@ -36,8 +36,8 @@ import java.util.UUID;
 public abstract class AbstractBackMatter implements IBackMatter {
 
   @Override
-  public Resource getResourceByUuid(@NotNull UUID uuid) {
-    List<@NotNull Resource> resources = getResources();
+  public Resource getResourceByUuid(@Nonnull UUID uuid) {
+    List<@Nonnull Resource> resources = getResources();
 
     Resource retval = null;
     if (resources != null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractBackMatter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractBackMatter.java
@@ -28,16 +28,16 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
 import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractBackMatter implements IBackMatter {
 
   @Override
-  public Resource getResourceByUuid(@Nonnull UUID uuid) {
-    List<@Nonnull Resource> resources = getResources();
+  public Resource getResourceByUuid(@NonNull UUID uuid) {
+    List<Resource> resources = getResources();
 
     Resource retval = null;
     if (resources != null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractLink.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractLink.java
@@ -29,52 +29,52 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupLine;
 import gov.nist.secauto.oscal.lib.model.Link;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.Objects;
 
 public abstract class AbstractLink implements ILink {
 
-  @NotNull
-  public static Builder builder(@NotNull URI href) {
+  @Nonnull
+  public static Builder builder(@Nonnull URI href) {
     return new Builder(href);
   }
 
   public static class Builder {
-    @NotNull
+    @Nonnull
     private final URI href;
     private String rel;
     private String mediaType;
     private MarkupLine text;
 
     @SuppressWarnings("null")
-    public Builder(@NotNull URI href) {
+    public Builder(@Nonnull URI href) {
       this.href = Objects.requireNonNull(href, "href");
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder relation(@NotNull String relation) {
+    @Nonnull
+    public Builder relation(@Nonnull String relation) {
       this.rel = Objects.requireNonNull(relation, "rel");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder value(@NotNull String mediaType) {
+    @Nonnull
+    public Builder value(@Nonnull String mediaType) {
       this.mediaType = Objects.requireNonNull(mediaType, "mediaType");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder clazz(@NotNull MarkupLine text) {
+    @Nonnull
+    public Builder clazz(@Nonnull MarkupLine text) {
       this.text = Objects.requireNonNull(text, "text");
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public Link build() {
       Link retval = new Link();
       retval.setHref(href);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractLink.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractLink.java
@@ -29,52 +29,61 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupLine;
 import gov.nist.secauto.oscal.lib.model.Link;
 
-import javax.annotation.Nonnull;
-
 import java.net.URI;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractLink implements ILink {
 
-  @Nonnull
-  public static Builder builder(@Nonnull URI href) {
+  public static List<Link> merge(@NonNull List<Link> original, @NonNull List<Link> additional) {
+    return Stream.concat(original.stream(), additional.stream())
+      .collect(Collectors.toCollection(LinkedList::new));
+  }
+
+  @NonNull
+  public static Builder builder(@NonNull URI href) {
     return new Builder(href);
   }
 
   public static class Builder {
-    @Nonnull
+    @NonNull
     private final URI href;
     private String rel;
     private String mediaType;
     private MarkupLine text;
 
     @SuppressWarnings("null")
-    public Builder(@Nonnull URI href) {
+    public Builder(@NonNull URI href) {
       this.href = Objects.requireNonNull(href, "href");
     }
 
     @SuppressWarnings("null")
-    @Nonnull
-    public Builder relation(@Nonnull String relation) {
+    @NonNull
+    public Builder relation(@NonNull String relation) {
       this.rel = Objects.requireNonNull(relation, "rel");
       return this;
     }
 
     @SuppressWarnings("null")
-    @Nonnull
-    public Builder value(@Nonnull String mediaType) {
+    @NonNull
+    public Builder value(@NonNull String mediaType) {
       this.mediaType = Objects.requireNonNull(mediaType, "mediaType");
       return this;
     }
 
     @SuppressWarnings("null")
-    @Nonnull
-    public Builder clazz(@Nonnull MarkupLine text) {
+    @NonNull
+    public Builder clazz(@NonNull MarkupLine text) {
       this.text = Objects.requireNonNull(text, "text");
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public Link build() {
       Link retval = new Link();
       retval.setHref(href);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractMetadata.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractMetadata.java
@@ -28,7 +28,7 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 
 import gov.nist.secauto.oscal.lib.model.Party;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.UUID;
@@ -36,8 +36,8 @@ import java.util.UUID;
 public abstract class AbstractMetadata implements IMetadata {
 
   @Override
-  public Party getPartyByUuid(@NotNull UUID uuid) {
-    List<@NotNull Party> parties = getParties();
+  public Party getPartyByUuid(@Nonnull UUID uuid) {
+    List<@Nonnull Party> parties = getParties();
 
     Party retval = null;
     if (parties != null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractMetadata.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractMetadata.java
@@ -28,16 +28,16 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 
 import gov.nist.secauto.oscal.lib.model.Party;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
 import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractMetadata implements IMetadata {
 
   @Override
-  public Party getPartyByUuid(@Nonnull UUID uuid) {
-    List<@Nonnull Party> parties = getParties();
+  public Party getPartyByUuid(@NonNull UUID uuid) {
+    List<Party> parties = getParties();
 
     Party retval = null;
     if (parties != null) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractProperty.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractProperty.java
@@ -29,29 +29,32 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import javax.annotation.Nonnull;
-
 import java.net.URI;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.xml.namespace.QName;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public abstract class AbstractProperty implements IProperty {
 
-  @Nonnull
-  public static QName qname(URI namespace, @Nonnull String name) {
+  @NonNull
+  public static QName qname(URI namespace, @NonNull String name) {
     return new QName(normalizeNamespace(namespace).toString(), name);
   }
 
-  @Nonnull
-  public static QName qname(@Nonnull String name) {
+  @NonNull
+  public static QName qname(@NonNull String name) {
     return new QName(OSCAL_NAMESPACE.toString(), name);
   }
 
-  @Nonnull
+  @NonNull
   public static URI normalizeNamespace(URI namespace) {
     URI propertyNamespace = namespace;
     if (propertyNamespace == null) {
@@ -61,8 +64,8 @@ public abstract class AbstractProperty implements IProperty {
   }
 
   @SuppressWarnings("null")
-  @Nonnull
-  public static Optional<Property> find(List<Property> props, @Nonnull QName qname) {
+  @NonNull
+  public static Optional<Property> find(List<Property> props, @NonNull QName qname) {
     return CollectionUtil.listOrEmpty(props).stream().filter(prop -> qname.equals(prop.getQName())).findFirst();
   }
 
@@ -70,68 +73,68 @@ public abstract class AbstractProperty implements IProperty {
     // only concrete classes should construct
   }
 
+  public static List<Property> merge(@NonNull List<Property> original, @NonNull List<Property> additional) {
+    return Stream.concat(original.stream(), additional.stream())
+      .collect(Collectors.toCollection(LinkedList::new));
+  }
+  
   @Override
-  public boolean isNamespaceEqual(@Nonnull URI namespace) {
+  public boolean isNamespaceEqual(@NonNull URI namespace) {
     return normalizeNamespace(getNs()).equals(namespace);
   }
 
-  @Nonnull
+  @NonNull
   public QName getQName() {
     return new QName(normalizeNamespace(getNs()).toString(), getName());
   }
 
-  @Nonnull
-  public static Builder builder(@Nonnull String name) {
+  @NonNull
+  public static Builder builder(@NonNull String name) {
     return new Builder(name);
   }
 
   public static class Builder {
-    @Nonnull
+    @NonNull
     private final String name;
 
-    private UUID uuid;
-    private URI namespace;
-    private String value;
-    private String clazz;
+    private UUID uuid; // NOPMD - intentional
+    private URI namespace; // NOPMD - intentional
+    private String value; // NOPMD - intentional
+    private String clazz; // NOPMD - intentional
 
-    @SuppressWarnings("null")
-    public Builder(@Nonnull String name) {
+    public Builder(@NonNull String name) {
       this.name = Objects.requireNonNull(name, "name");
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder uuid(@Nonnull UUID uuid) {
-      this.uuid = Objects.requireNonNull(uuid, "uuid");
+    @NonNull
+    public Builder uuid(@NonNull UUID uuid) {
+      this.uuid = Objects.requireNonNull(uuid);
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder namespace(@Nonnull URI namespace) {
+    @NonNull
+    public Builder namespace(@NonNull URI namespace) {
       if (IProperty.OSCAL_NAMESPACE.equals(namespace)) {
-        this.namespace = null;
+        this.namespace = null; // NOPMD - ok
       } else {
-        this.namespace = Objects.requireNonNull(namespace, "namespace");
+        this.namespace = Objects.requireNonNull(namespace);
       }
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder value(@Nonnull String value) {
-      this.value = Objects.requireNonNull(value, "value");
+    @NonNull
+    public Builder value(@NonNull String value) {
+      this.value = Objects.requireNonNull(value);
       return this;
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Builder clazz(@Nonnull String clazz) {
-      this.clazz = Objects.requireNonNull(clazz, "clazz");
+    @NonNull
+    public Builder clazz(@NonNull String clazz) {
+      this.clazz = Objects.requireNonNull(clazz);
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public Property build() {
       Property retval = new Property();
       retval.setName(name);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractProperty.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/AbstractProperty.java
@@ -29,7 +29,7 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.oscal.lib.model.Property;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
@@ -41,17 +41,17 @@ import javax.xml.namespace.QName;
 
 public abstract class AbstractProperty implements IProperty {
 
-  @NotNull
-  public static QName qname(URI namespace, @NotNull String name) {
+  @Nonnull
+  public static QName qname(URI namespace, @Nonnull String name) {
     return new QName(normalizeNamespace(namespace).toString(), name);
   }
 
-  @NotNull
-  public static QName qname(@NotNull String name) {
+  @Nonnull
+  public static QName qname(@Nonnull String name) {
     return new QName(OSCAL_NAMESPACE.toString(), name);
   }
 
-  @NotNull
+  @Nonnull
   public static URI normalizeNamespace(URI namespace) {
     URI propertyNamespace = namespace;
     if (propertyNamespace == null) {
@@ -61,8 +61,8 @@ public abstract class AbstractProperty implements IProperty {
   }
 
   @SuppressWarnings("null")
-  @NotNull
-  public static Optional<Property> find(List<Property> props, @NotNull QName qname) {
+  @Nonnull
+  public static Optional<Property> find(List<Property> props, @Nonnull QName qname) {
     return CollectionUtil.listOrEmpty(props).stream().filter(prop -> qname.equals(prop.getQName())).findFirst();
   }
 
@@ -71,22 +71,22 @@ public abstract class AbstractProperty implements IProperty {
   }
 
   @Override
-  public boolean isNamespaceEqual(@NotNull URI namespace) {
+  public boolean isNamespaceEqual(@Nonnull URI namespace) {
     return normalizeNamespace(getNs()).equals(namespace);
   }
 
-  @NotNull
+  @Nonnull
   public QName getQName() {
     return new QName(normalizeNamespace(getNs()).toString(), getName());
   }
 
-  @NotNull
-  public static Builder builder(@NotNull String name) {
+  @Nonnull
+  public static Builder builder(@Nonnull String name) {
     return new Builder(name);
   }
 
   public static class Builder {
-    @NotNull
+    @Nonnull
     private final String name;
 
     private UUID uuid;
@@ -95,20 +95,20 @@ public abstract class AbstractProperty implements IProperty {
     private String clazz;
 
     @SuppressWarnings("null")
-    public Builder(@NotNull String name) {
+    public Builder(@Nonnull String name) {
       this.name = Objects.requireNonNull(name, "name");
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder uuid(@NotNull UUID uuid) {
+    @Nonnull
+    public Builder uuid(@Nonnull UUID uuid) {
       this.uuid = Objects.requireNonNull(uuid, "uuid");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder namespace(@NotNull URI namespace) {
+    @Nonnull
+    public Builder namespace(@Nonnull URI namespace) {
       if (IProperty.OSCAL_NAMESPACE.equals(namespace)) {
         this.namespace = null;
       } else {
@@ -118,20 +118,20 @@ public abstract class AbstractProperty implements IProperty {
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder value(@NotNull String value) {
+    @Nonnull
+    public Builder value(@Nonnull String value) {
       this.value = Objects.requireNonNull(value, "value");
       return this;
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Builder clazz(@NotNull String clazz) {
+    @Nonnull
+    public Builder clazz(@Nonnull String clazz) {
       this.clazz = Objects.requireNonNull(clazz, "clazz");
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public Property build() {
       Property retval = new Property();
       retval.setName(name);

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IBackMatter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IBackMatter.java
@@ -28,15 +28,16 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 
-import javax.annotation.Nonnull;
-import org.jetbrains.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public interface IBackMatter {
-  List<@Nonnull Resource> getResources();
+  List<Resource> getResources();
 
   @Nullable
-  Resource getResourceByUuid(@Nonnull UUID uuid);
+  Resource getResourceByUuid(@NonNull UUID uuid);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IBackMatter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IBackMatter.java
@@ -28,15 +28,15 @@ package gov.nist.secauto.oscal.lib.model.metadata;
 
 import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface IBackMatter {
-  List<@NotNull Resource> getResources();
+  List<@Nonnull Resource> getResources();
 
   @Nullable
-  Resource getResourceByUuid(@NotNull UUID uuid);
+  Resource getResourceByUuid(@Nonnull UUID uuid);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/ILink.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/ILink.java
@@ -27,5 +27,5 @@
 package gov.nist.secauto.oscal.lib.model.metadata;
 
 public interface ILink {
-
+  // no additional methods
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IMetadata.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IMetadata.java
@@ -30,7 +30,7 @@ import gov.nist.secauto.oscal.lib.model.Location;
 import gov.nist.secauto.oscal.lib.model.Party;
 import gov.nist.secauto.oscal.lib.model.Role;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -38,11 +38,11 @@ import java.util.UUID;
 
 public interface IMetadata {
   @Nullable
-  Party getPartyByUuid(@NotNull UUID uuid);
+  Party getPartyByUuid(@Nonnull UUID uuid);
 
-  List<@NotNull Role> getRoles();
+  List<@Nonnull Role> getRoles();
 
-  List<@NotNull Location> getLocations();
+  List<@Nonnull Location> getLocations();
 
-  List<@NotNull Party> getParties();
+  List<@Nonnull Party> getParties();
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IMetadata.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IMetadata.java
@@ -30,19 +30,19 @@ import gov.nist.secauto.oscal.lib.model.Location;
 import gov.nist.secauto.oscal.lib.model.Party;
 import gov.nist.secauto.oscal.lib.model.Role;
 
-import javax.annotation.Nonnull;
-import org.jetbrains.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface IMetadata {
   @Nullable
-  Party getPartyByUuid(@Nonnull UUID uuid);
+  Party getPartyByUuid(@NonNull UUID uuid);
 
-  List<@Nonnull Role> getRoles();
+  List<Role> getRoles();
 
-  List<@Nonnull Location> getLocations();
+  List<Location> getLocations();
 
-  List<@Nonnull Party> getParties();
+  List<Party> getParties();
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IProperty.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IProperty.java
@@ -26,21 +26,21 @@
 
 package gov.nist.secauto.oscal.lib.model.metadata;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.net.URI;
 
 public interface IProperty {
   @SuppressWarnings("null")
-  @Nonnull
+  @NonNull
   URI OSCAL_NAMESPACE = URI.create("http://csrc.nist.gov/ns/oscal");
   @SuppressWarnings("null")
-  @Nonnull
+  @NonNull
   URI RMF_NAMESPACE = URI.create("http://csrc.nist.gov/ns/rmf");
 
   String getName();
 
   URI getNs();
 
-  boolean isNamespaceEqual(@Nonnull URI namespace);
+  boolean isNamespaceEqual(@NonNull URI namespace);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IProperty.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/metadata/IProperty.java
@@ -26,21 +26,21 @@
 
 package gov.nist.secauto.oscal.lib.model.metadata;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 
 public interface IProperty {
   @SuppressWarnings("null")
-  @NotNull
+  @Nonnull
   URI OSCAL_NAMESPACE = URI.create("http://csrc.nist.gov/ns/oscal");
   @SuppressWarnings("null")
-  @NotNull
+  @Nonnull
   URI RMF_NAMESPACE = URI.create("http://csrc.nist.gov/ns/rmf");
 
   String getName();
 
   URI getNs();
 
-  boolean isNamespaceEqual(@NotNull URI namespace);
+  boolean isNamespaceEqual(@Nonnull URI namespace);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/AbstractCatalogControlItemVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/AbstractCatalogControlItemVisitor.java
@@ -29,7 +29,7 @@ package gov.nist.secauto.oscal.lib.profile.resolver;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractCatalogControlItemVisitor<T, R> {
 
@@ -37,11 +37,11 @@ public abstract class AbstractCatalogControlItemVisitor<T, R> {
 
   protected abstract R aggregateResults(R first, R second, T context);
 
-  protected R visitCatalog(@Nonnull IDocumentNodeItem profileDocument, T context) {
+  protected R visitCatalog(@NonNull IDocumentNodeItem profileDocument, T context) {
     return visitGroupContainer(profileDocument.getRootAssemblyNodeItem(), context);
   }
 
-  protected R visitGroupContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroup, T context) {
+  protected R visitGroupContainer(@NonNull IRequiredValueModelNodeItem catalogOrGroup, T context) {
     R groupResult = catalogOrGroup.getModelItemsByName("group").stream()
         .map(groupItem -> {
           return visitGroup(groupItem, context);
@@ -52,7 +52,7 @@ public abstract class AbstractCatalogControlItemVisitor<T, R> {
     return aggregateResults(groupResult, controlResult, context);
   }
 
-  protected R visitControlContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroupOrControl, T context) {
+  protected R visitControlContainer(@NonNull IRequiredValueModelNodeItem catalogOrGroupOrControl, T context) {
     return catalogOrGroupOrControl.getModelItemsByName("control").stream()
         .map(controlItem -> {
           return visitControl(controlItem, context);
@@ -60,11 +60,11 @@ public abstract class AbstractCatalogControlItemVisitor<T, R> {
         .reduce(newDefaultResult(context), (first, second) -> aggregateResults(first, second, context));
   }
 
-  protected R visitGroup(@Nonnull IRequiredValueModelNodeItem groupItem, T context) {
+  protected R visitGroup(@NonNull IRequiredValueModelNodeItem groupItem, T context) {
     return visitGroupContainer(groupItem, context);
   }
 
-  protected R visitControl(@Nonnull IRequiredValueModelNodeItem controlItem, T context) {
+  protected R visitControl(@NonNull IRequiredValueModelNodeItem controlItem, T context) {
     return visitControlContainer(controlItem, context);
   }
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/AbstractCatalogControlItemVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/AbstractCatalogControlItemVisitor.java
@@ -29,7 +29,7 @@ package gov.nist.secauto.oscal.lib.profile.resolver;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public abstract class AbstractCatalogControlItemVisitor<T, R> {
 
@@ -37,11 +37,11 @@ public abstract class AbstractCatalogControlItemVisitor<T, R> {
 
   protected abstract R aggregateResults(R first, R second, T context);
 
-  protected R visitCatalog(@NotNull IDocumentNodeItem profileDocument, T context) {
+  protected R visitCatalog(@Nonnull IDocumentNodeItem profileDocument, T context) {
     return visitGroupContainer(profileDocument.getRootAssemblyNodeItem(), context);
   }
 
-  protected R visitGroupContainer(@NotNull IRequiredValueModelNodeItem catalogOrGroup, T context) {
+  protected R visitGroupContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroup, T context) {
     R groupResult = catalogOrGroup.getModelItemsByName("group").stream()
         .map(groupItem -> {
           return visitGroup(groupItem, context);
@@ -52,7 +52,7 @@ public abstract class AbstractCatalogControlItemVisitor<T, R> {
     return aggregateResults(groupResult, controlResult, context);
   }
 
-  protected R visitControlContainer(@NotNull IRequiredValueModelNodeItem catalogOrGroupOrControl, T context) {
+  protected R visitControlContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroupOrControl, T context) {
     return catalogOrGroupOrControl.getModelItemsByName("control").stream()
         .map(controlItem -> {
           return visitControl(controlItem, context);
@@ -60,11 +60,11 @@ public abstract class AbstractCatalogControlItemVisitor<T, R> {
         .reduce(newDefaultResult(context), (first, second) -> aggregateResults(first, second, context));
   }
 
-  protected R visitGroup(@NotNull IRequiredValueModelNodeItem groupItem, T context) {
+  protected R visitGroup(@Nonnull IRequiredValueModelNodeItem groupItem, T context) {
     return visitGroupContainer(groupItem, context);
   }
 
-  protected R visitControl(@NotNull IRequiredValueModelNodeItem controlItem, T context) {
+  protected R visitControl(@Nonnull IRequiredValueModelNodeItem controlItem, T context) {
     return visitControlContainer(controlItem, context);
   }
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlIndexingVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlIndexingVisitor.java
@@ -1,0 +1,57 @@
+
+package gov.nist.secauto.oscal.lib.profile.resolver;
+
+import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
+import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
+
+import javax.annotation.Nonnull;
+
+public class ControlIndexingVisitor
+    extends AbstractCatalogControlItemVisitor<Void, Void> {
+  @Nonnull
+  private final IIndexer indexer;
+
+  public ControlIndexingVisitor(@Nonnull IIdentifierMapper mapper) {
+    this.indexer = new DefaultIndexer(mapper);
+  }
+
+  @Nonnull
+  protected IIndexer getIndexer() {
+    return indexer;
+  }
+
+  @Nonnull
+  public Index getIndex() {
+    return indexer.getIndex();
+  }
+
+  @Override
+  protected Void visitCatalog(@Nonnull IDocumentNodeItem catalogItem, Void context) {
+    return super.visitCatalog(catalogItem, null);
+  }
+
+  @Override
+  protected Void visitControl(@Nonnull IRequiredValueModelNodeItem controlItem, Void context) {
+    getIndexer().addControl(controlItem, true);
+    return super.visitControl(controlItem, context);
+  }
+  @Override
+  protected Void visitControlContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroupOrControl,
+      Void context) {
+    // handle parameters
+    catalogOrGroupOrControl.getModelItemsByName("param").forEach(paramItem -> {
+      getIndexer().addParameter(paramItem);
+    });
+    return super.visitControlContainer(catalogOrGroupOrControl, null);
+  }
+
+  @Override
+  protected Void newDefaultResult(Void context) {
+    return null;
+  }
+
+  @Override
+  protected Void aggregateResults(Void first, Void second, Void context) {
+    return null;
+  }
+}

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlIndexingVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlIndexingVisitor.java
@@ -1,42 +1,68 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
 
 package gov.nist.secauto.oscal.lib.profile.resolver;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class ControlIndexingVisitor
     extends AbstractCatalogControlItemVisitor<Void, Void> {
-  @Nonnull
+  @NonNull
   private final IIndexer indexer;
 
-  public ControlIndexingVisitor(@Nonnull IIdentifierMapper mapper) {
+  public ControlIndexingVisitor(@NonNull IIdentifierMapper mapper) {
     this.indexer = new DefaultIndexer(mapper);
   }
 
-  @Nonnull
+  @NonNull
   protected IIndexer getIndexer() {
     return indexer;
   }
 
-  @Nonnull
+  @NonNull
   public Index getIndex() {
     return indexer.getIndex();
   }
 
   @Override
-  protected Void visitCatalog(@Nonnull IDocumentNodeItem catalogItem, Void context) {
+  protected Void visitCatalog(@NonNull IDocumentNodeItem catalogItem, Void context) {
     return super.visitCatalog(catalogItem, null);
   }
 
   @Override
-  protected Void visitControl(@Nonnull IRequiredValueModelNodeItem controlItem, Void context) {
+  protected Void visitControl(@NonNull IRequiredValueModelNodeItem controlItem, Void context) {
     getIndexer().addControl(controlItem, true);
     return super.visitControl(controlItem, context);
   }
+
   @Override
-  protected Void visitControlContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroupOrControl,
+  protected Void visitControlContainer(@NonNull IRequiredValueModelNodeItem catalogOrGroupOrControl,
       Void context) {
     // handle parameters
     catalogOrGroupOrControl.getModelItemsByName("param").forEach(paramItem -> {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlSelectionVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlSelectionVisitor.java
@@ -36,35 +36,35 @@ import gov.nist.secauto.oscal.lib.model.Control;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public class ControlSelectionVisitor
-    extends AbstractCatalogControlItemVisitor<Boolean, @NotNull Boolean> {
+    extends AbstractCatalogControlItemVisitor<@Nonnull Boolean, @Nonnull Boolean> {
   private static final Logger LOGGER = LogManager.getLogger(ControlSelectionVisitor.class);
 
-  @NotNull
+  @Nonnull
   private static final MetapathExpression BACK_MATTER_RESOURCES_METAPATH
       = MetapathExpression.compile("back-matter/resource");
-  @NotNull
+  @Nonnull
   private static final MetapathExpression PART_METAPATH
       = MetapathExpression.compile("part|part//part");
 
-  @NotNull
+  @Nonnull
   private final IControlFilter filter;
-  @NotNull
+  @Nonnull
   private final IIndexer indexer;
 
-  public ControlSelectionVisitor(@NotNull IControlFilter filter, @NotNull IIdentifierMapper mapper) {
+  public ControlSelectionVisitor(@Nonnull IControlFilter filter, @Nonnull IIdentifierMapper mapper) {
     this.filter = filter;
     this.indexer = new DefaultIndexer(mapper);
   }
 
-  @NotNull
+  @Nonnull
   protected IIndexer getIndexer() {
     return indexer;
   }
 
-  @NotNull
+  @Nonnull
   public Index getIndex() {
     return indexer.getIndex();
   }
@@ -79,13 +79,13 @@ public class ControlSelectionVisitor
     return first || second;
   }
 
-  public void visitProfile(@NotNull IDocumentNodeItem profileItem) {
+  public void visitProfile(@Nonnull IDocumentNodeItem profileItem) {
     IRootAssemblyNodeItem root = profileItem.getRootAssemblyNodeItem();
     indexMetadata(root);
     indexBackMatter(root);
   }
 
-  public void visitCatalog(@NotNull IDocumentNodeItem catalogItem) {
+  public void visitCatalog(@Nonnull IDocumentNodeItem catalogItem) {
     visitCatalog(catalogItem, false);
 
     IRootAssemblyNodeItem root = catalogItem.getRootAssemblyNodeItem();
@@ -94,7 +94,7 @@ public class ControlSelectionVisitor
   }
 
   @Override
-  protected Boolean visitGroup(@NotNull IRequiredValueModelNodeItem groupItem, Boolean defaultMatch) {
+  protected Boolean visitGroup(@Nonnull IRequiredValueModelNodeItem groupItem, Boolean defaultMatch) {
     boolean result = super.visitGroup(groupItem, defaultMatch);
 
     CatalogGroup group = (CatalogGroup) groupItem.getValue();
@@ -107,11 +107,11 @@ public class ControlSelectionVisitor
   }
 
   @Override
-  protected Boolean visitControl(@NotNull IRequiredValueModelNodeItem controlItem, Boolean defaultMatch) {
+  protected Boolean visitControl(@Nonnull IRequiredValueModelNodeItem controlItem, Boolean defaultMatch) {
     Control control = (Control) controlItem.getValue();
 
     // determine if the control is a match
-    Pair<@NotNull Boolean, @NotNull Boolean> matchResult = filter.match(control, defaultMatch);
+    Pair<@Nonnull Boolean, @Nonnull Boolean> matchResult = filter.match(control, defaultMatch);
     @SuppressWarnings("null")
     boolean isMatch = matchResult.getLeft();
     @SuppressWarnings("null")
@@ -125,11 +125,11 @@ public class ControlSelectionVisitor
 
     boolean defaultChildMatch = isMatch && isWithChildren;
 
-    return aggregateResults(isMatch, super.visitControl(controlItem, defaultChildMatch), null);
+    return aggregateResults(isMatch, super.visitControl(controlItem, defaultChildMatch), defaultMatch);
   }
 
   @Override
-  protected Boolean visitControlContainer(@NotNull IRequiredValueModelNodeItem catalogOrGroupOrControl,
+  protected Boolean visitControlContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroupOrControl,
       Boolean defaultMatch) {
     boolean retval = super.visitControlContainer(catalogOrGroupOrControl, defaultMatch);
 
@@ -140,14 +140,14 @@ public class ControlSelectionVisitor
 
     // handle parts
     PART_METAPATH.evaluate(catalogOrGroupOrControl).asStream()
-        .map(item -> (@NotNull IRequiredValueModelNodeItem) item)
+        .map(item -> (@Nonnull IRequiredValueModelNodeItem) item)
         .forEachOrdered(partItem -> {
           indexer.addPart(partItem);
         });
     return retval;
   }
 
-  protected void indexMetadata(@NotNull IRootAssemblyNodeItem rootItem) {
+  protected void indexMetadata(@Nonnull IRootAssemblyNodeItem rootItem) {
     IIndexer indexer = getIndexer();
 
     rootItem.getModelItemsByName("metadata").forEach(metadataItem -> {
@@ -165,10 +165,10 @@ public class ControlSelectionVisitor
     });
   }
 
-  protected void indexBackMatter(@NotNull IRootAssemblyNodeItem rootItem) {
+  protected void indexBackMatter(@Nonnull IRootAssemblyNodeItem rootItem) {
     IIndexer indexer = getIndexer();
     BACK_MATTER_RESOURCES_METAPATH.evaluate(rootItem).asStream()
-        .map(item -> (@NotNull IRequiredValueModelNodeItem) item)
+        .map(item -> (@Nonnull IRequiredValueModelNodeItem) item)
         .forEachOrdered(resourceItem -> {
           indexer.addResource(resourceItem);
         });

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlSelectionVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ControlSelectionVisitor.java
@@ -36,35 +36,36 @@ import gov.nist.secauto.oscal.lib.model.Control;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class ControlSelectionVisitor
-    extends AbstractCatalogControlItemVisitor<@Nonnull Boolean, @Nonnull Boolean> {
+    extends AbstractCatalogControlItemVisitor<Boolean, Boolean> {
   private static final Logger LOGGER = LogManager.getLogger(ControlSelectionVisitor.class);
 
-  @Nonnull
+  @NonNull
   private static final MetapathExpression BACK_MATTER_RESOURCES_METAPATH
       = MetapathExpression.compile("back-matter/resource");
-  @Nonnull
+  @NonNull
   private static final MetapathExpression PART_METAPATH
       = MetapathExpression.compile("part|part//part");
 
-  @Nonnull
+  @NonNull
   private final IControlFilter filter;
-  @Nonnull
+  @NonNull
   private final IIndexer indexer;
 
-  public ControlSelectionVisitor(@Nonnull IControlFilter filter, @Nonnull IIdentifierMapper mapper) {
+  public ControlSelectionVisitor(@NonNull IControlFilter filter, @NonNull IIdentifierMapper mapper) {
     this.filter = filter;
     this.indexer = new DefaultIndexer(mapper);
   }
 
-  @Nonnull
+  @NonNull
   protected IIndexer getIndexer() {
     return indexer;
   }
 
-  @Nonnull
+  @NonNull
   public Index getIndex() {
     return indexer.getIndex();
   }
@@ -79,13 +80,13 @@ public class ControlSelectionVisitor
     return first || second;
   }
 
-  public void visitProfile(@Nonnull IDocumentNodeItem profileItem) {
+  public void visitProfile(@NonNull IDocumentNodeItem profileItem) {
     IRootAssemblyNodeItem root = profileItem.getRootAssemblyNodeItem();
     indexMetadata(root);
     indexBackMatter(root);
   }
 
-  public void visitCatalog(@Nonnull IDocumentNodeItem catalogItem) {
+  public void visitCatalog(@NonNull IDocumentNodeItem catalogItem) {
     visitCatalog(catalogItem, false);
 
     IRootAssemblyNodeItem root = catalogItem.getRootAssemblyNodeItem();
@@ -94,7 +95,7 @@ public class ControlSelectionVisitor
   }
 
   @Override
-  protected Boolean visitGroup(@Nonnull IRequiredValueModelNodeItem groupItem, Boolean defaultMatch) {
+  protected Boolean visitGroup(@NonNull IRequiredValueModelNodeItem groupItem, Boolean defaultMatch) {
     boolean result = super.visitGroup(groupItem, defaultMatch);
 
     CatalogGroup group = (CatalogGroup) groupItem.getValue();
@@ -107,11 +108,11 @@ public class ControlSelectionVisitor
   }
 
   @Override
-  protected Boolean visitControl(@Nonnull IRequiredValueModelNodeItem controlItem, Boolean defaultMatch) {
+  protected Boolean visitControl(@NonNull IRequiredValueModelNodeItem controlItem, Boolean defaultMatch) {
     Control control = (Control) controlItem.getValue();
 
     // determine if the control is a match
-    Pair<@Nonnull Boolean, @Nonnull Boolean> matchResult = filter.match(control, defaultMatch);
+    Pair<Boolean, Boolean> matchResult = filter.match(control, defaultMatch);
     @SuppressWarnings("null")
     boolean isMatch = matchResult.getLeft();
     @SuppressWarnings("null")
@@ -129,7 +130,7 @@ public class ControlSelectionVisitor
   }
 
   @Override
-  protected Boolean visitControlContainer(@Nonnull IRequiredValueModelNodeItem catalogOrGroupOrControl,
+  protected Boolean visitControlContainer(@NonNull IRequiredValueModelNodeItem catalogOrGroupOrControl,
       Boolean defaultMatch) {
     boolean retval = super.visitControlContainer(catalogOrGroupOrControl, defaultMatch);
 
@@ -140,14 +141,14 @@ public class ControlSelectionVisitor
 
     // handle parts
     PART_METAPATH.evaluate(catalogOrGroupOrControl).asStream()
-        .map(item -> (@Nonnull IRequiredValueModelNodeItem) item)
+        .map(item -> (IRequiredValueModelNodeItem) item)
         .forEachOrdered(partItem -> {
           indexer.addPart(partItem);
         });
     return retval;
   }
 
-  protected void indexMetadata(@Nonnull IRootAssemblyNodeItem rootItem) {
+  protected void indexMetadata(@NonNull IRootAssemblyNodeItem rootItem) {
     IIndexer indexer = getIndexer();
 
     rootItem.getModelItemsByName("metadata").forEach(metadataItem -> {
@@ -165,10 +166,10 @@ public class ControlSelectionVisitor
     });
   }
 
-  protected void indexBackMatter(@Nonnull IRootAssemblyNodeItem rootItem) {
+  protected void indexBackMatter(@NonNull IRootAssemblyNodeItem rootItem) {
     IIndexer indexer = getIndexer();
     BACK_MATTER_RESOURCES_METAPATH.evaluate(rootItem).asStream()
-        .map(item -> (@Nonnull IRequiredValueModelNodeItem) item)
+        .map(item -> (IRequiredValueModelNodeItem) item)
         .forEachOrdered(resourceItem -> {
           indexer.addResource(resourceItem);
         });

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilter.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.oscal.lib.model.control.profile.IProfileSelectControlByI
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Collections;
 import java.util.List;
@@ -46,8 +46,8 @@ import java.util.stream.Collectors;
 public class DefaultControlSelectionFilter implements IControlSelectionFilter {
   private static final Logger LOGGER = LogManager.getLogger(DefaultControlSelectionFilter.class);
 
-  @NotNull
-  private final List<@NotNull Selection> selections;
+  @Nonnull
+  private final List<@Nonnull Selection> selections;
 
   /**
    * Construct a new selection filter based on the provided list of select criteria.
@@ -56,7 +56,7 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
    *          a list of select criteria
    */
   @SuppressWarnings("null")
-  public DefaultControlSelectionFilter(@NotNull List<? extends IProfileSelectControlById> selections) {
+  public DefaultControlSelectionFilter(@Nonnull List<? extends IProfileSelectControlById> selections) {
     this.selections = selections.stream()
         // ignore null entries
         .filter(Objects::nonNull)
@@ -65,9 +65,9 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
         .collect(Collectors.toUnmodifiableList());
   }
 
-  @NotNull
+  @Nonnull
   @Override
-  public Pair<@NotNull Boolean, @NotNull Boolean> apply(@NotNull IControl control) {
+  public Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
     String id = control.getId();
     if (id == null) {
       throw new IllegalArgumentException("control is missing an identifier");
@@ -85,15 +85,15 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
    *         {@code false} otherwise
    */
   @SuppressWarnings("null")
-  @NotNull
-  protected Pair<@NotNull Boolean, @NotNull Boolean> match(String id) {
+  @Nonnull
+  protected Pair<@Nonnull Boolean, @Nonnull Boolean> match(String id) {
     return selections.parallelStream()
         .map(selection -> selection.match(id))
         // filter out non-matches
         .filter(pair -> pair.getLeft())
         // aggregate matches
         .reduce((first, second) -> {
-          Pair<@NotNull Boolean, @NotNull Boolean> result;
+          Pair<@Nonnull Boolean, @Nonnull Boolean> result;
           if (first.getLeft() || second.getLeft()) {
             // at least one matches
             boolean withChild = first.getLeft() && first.getRight() || second.getLeft() && second.getRight();
@@ -106,7 +106,7 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
         .orElse(NON_MATCH);
   }
 
-  private static Pattern toPattern(@NotNull ProfileSelectControlById.Matching matching) {
+  private static Pattern toPattern(@Nonnull ProfileSelectControlById.Matching matching) {
     String pattern = matching.getPattern();
     if (pattern == null) {
       throw new IllegalArgumentException("pattern is null");
@@ -181,8 +181,8 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
       return withChildControls;
     }
 
-    @NotNull
-    protected Pair<@NotNull Boolean, @NotNull Boolean> match(String id) {
+    @Nonnull
+    protected Pair<@Nonnull Boolean, @Nonnull Boolean> match(String id) {
       // first check for direct match
       boolean result = identifiers.stream().anyMatch(controlIdentifier -> controlIdentifier.equals(id));
       if (!result) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilter.java
@@ -34,7 +34,6 @@ import gov.nist.secauto.oscal.lib.model.control.profile.IProfileSelectControlByI
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,11 +42,13 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public class DefaultControlSelectionFilter implements IControlSelectionFilter {
   private static final Logger LOGGER = LogManager.getLogger(DefaultControlSelectionFilter.class);
 
-  @Nonnull
-  private final List<@Nonnull Selection> selections;
+  @NonNull
+  private final List<Selection> selections;
 
   /**
    * Construct a new selection filter based on the provided list of select criteria.
@@ -56,7 +57,7 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
    *          a list of select criteria
    */
   @SuppressWarnings("null")
-  public DefaultControlSelectionFilter(@Nonnull List<? extends IProfileSelectControlById> selections) {
+  public DefaultControlSelectionFilter(@NonNull List<? extends IProfileSelectControlById> selections) {
     this.selections = selections.stream()
         // ignore null entries
         .filter(Objects::nonNull)
@@ -65,12 +66,12 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
         .collect(Collectors.toUnmodifiableList());
   }
 
-  @Nonnull
+  @NonNull
   @Override
-  public Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
+  public Pair<Boolean, Boolean> apply(IControl control) {
     String id = control.getId();
     if (id == null) {
-      throw new IllegalArgumentException("control is missing an identifier");
+      throw new ProfileResolutionEvaluationException("control is missing an identifier");
     }
     return match(id);
   }
@@ -85,15 +86,15 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
    *         {@code false} otherwise
    */
   @SuppressWarnings("null")
-  @Nonnull
-  protected Pair<@Nonnull Boolean, @Nonnull Boolean> match(String id) {
+  @NonNull
+  protected Pair<Boolean, Boolean> match(String id) {
     return selections.parallelStream()
         .map(selection -> selection.match(id))
         // filter out non-matches
         .filter(pair -> pair.getLeft())
         // aggregate matches
         .reduce((first, second) -> {
-          Pair<@Nonnull Boolean, @Nonnull Boolean> result;
+          Pair<Boolean, Boolean> result;
           if (first.getLeft() || second.getLeft()) {
             // at least one matches
             boolean withChild = first.getLeft() && first.getRight() || second.getLeft() && second.getRight();
@@ -106,11 +107,8 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
         .orElse(NON_MATCH);
   }
 
-  private static Pattern toPattern(@Nonnull ProfileSelectControlById.Matching matching) {
-    String pattern = matching.getPattern();
-    if (pattern == null) {
-      throw new IllegalArgumentException("pattern is null");
-    }
+  private static Pattern toPattern(@NonNull ProfileSelectControlById.Matching matching) {
+    String pattern = ObjectUtils.requireNonNull(matching.getPattern());
     String regex = pattern.chars().boxed().map(ch -> (char) ch.intValue()).map(ch -> {
 
       String value;
@@ -146,7 +144,7 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
     return Pattern.compile(regex);
   }
 
-  private class Selection {
+  private static class Selection {
 
     private final boolean withChildControls;
     private final Set<String> identifiers;
@@ -181,8 +179,8 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
       return withChildControls;
     }
 
-    @Nonnull
-    protected Pair<@Nonnull Boolean, @Nonnull Boolean> match(String id) {
+    @NonNull
+    protected Pair<Boolean, Boolean> match(String id) {
       // first check for direct match
       boolean result = identifiers.stream().anyMatch(controlIdentifier -> controlIdentifier.equals(id));
       if (!result) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultIndexer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultIndexer.java
@@ -38,38 +38,41 @@ import gov.nist.secauto.oscal.lib.model.Party;
 import gov.nist.secauto.oscal.lib.model.Role;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.UUID;
 
 public class DefaultIndexer implements IIndexer {
-  @Nonnull
+  @NonNull
   private final Index index;
-  @Nonnull
+  @NonNull
   private final IIdentifierMapper mapper;
 
-  public DefaultIndexer(@Nonnull IIdentifierMapper mapper) {
+  public DefaultIndexer(@NonNull IIdentifierMapper mapper) {
     this(new Index(), mapper);
   }
 
-  public DefaultIndexer(@Nonnull Index index, @Nonnull IIdentifierMapper mapper) {
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "intending to store this parameter")
+  public DefaultIndexer(@NonNull Index index, @NonNull IIdentifierMapper mapper) {
     this.index = index;
     this.mapper = mapper;
   }
 
   @Override
-  @Nonnull
+  @NonNull
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intending to expose this field")
   public Index getIndex() {
     return index;
   }
 
-  @Nonnull
+  @NonNull
   protected IIdentifierMapper getMapper() {
     return mapper;
   }
 
   @Override
-  public EntityItem addRole(@Nonnull IRequiredValueModelNodeItem item) {
+  public EntityItem addRole(@NonNull IRequiredValueModelNodeItem item) {
     Role role = (Role) item.getValue();
     String identifier = ObjectUtils.notNull(role.getId());
     String mappedIdentifier = getMapper().mapRoleIdentifier(identifier);
@@ -84,7 +87,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addLocation(@Nonnull IRequiredValueModelNodeItem item) {
+  public EntityItem addLocation(@NonNull IRequiredValueModelNodeItem item) {
     Location location = (Location) item.getValue();
     UUID identifier = ObjectUtils.notNull(location.getUuid());
 
@@ -95,7 +98,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addParty(@Nonnull IRequiredValueModelNodeItem item) {
+  public EntityItem addParty(@NonNull IRequiredValueModelNodeItem item) {
     Party party = (Party) item.getValue();
     UUID identifier = ObjectUtils.notNull(party.getUuid());
 
@@ -106,7 +109,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addGroup(@Nonnull IRequiredValueModelNodeItem item, boolean selected) {
+  public EntityItem addGroup(@NonNull IRequiredValueModelNodeItem item, boolean selected) {
     CatalogGroup group = (CatalogGroup) item.getValue();
 
     if (selected) {
@@ -131,7 +134,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addControl(@Nonnull IRequiredValueModelNodeItem item, boolean selected) {
+  public EntityItem addControl(@NonNull IRequiredValueModelNodeItem item, boolean selected) {
     Control control = (Control) item.getValue();
     String identifier = ObjectUtils.notNull(control.getId());
     String mappedIdentifier = getMapper().mapControlIdentifier(identifier);
@@ -150,7 +153,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addParameter(@Nonnull IRequiredValueModelNodeItem item) {
+  public EntityItem addParameter(@NonNull IRequiredValueModelNodeItem item) {
     Parameter parameter = (Parameter) item.getValue();
     String identifier = ObjectUtils.notNull(parameter.getId());
     String mappedIdentifier = getMapper().mapParameterIdentifier(identifier);
@@ -165,7 +168,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addPart(@Nonnull IRequiredValueModelNodeItem item) {
+  public EntityItem addPart(@NonNull IRequiredValueModelNodeItem item) {
     ControlPart part = (ControlPart) item.getValue();
     String identifier = part.getId();
 
@@ -186,7 +189,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addResource(@Nonnull IRequiredValueModelNodeItem item) {
+  public EntityItem addResource(@NonNull IRequiredValueModelNodeItem item) {
     Resource resource = (Resource) item.getValue();
     UUID identifier = ObjectUtils.notNull(resource.getUuid());
 
@@ -196,39 +199,35 @@ public class DefaultIndexer implements IIndexer {
         identifier);
   }
 
-  protected <T> EntityItem addItem(@Nonnull ItemType type, @Nonnull IRequiredValueModelNodeItem item,
-      @Nonnull UUID identifier) {
+  protected <T> EntityItem addItem(@NonNull ItemType type, @NonNull IRequiredValueModelNodeItem item,
+      @NonNull UUID identifier) {
     EntityItem.Builder builder = EntityItem.builder()
-        .instance(item, identifier)
+        .instance(item, type, identifier)
         .source(ObjectUtils.requireNonNull(item.getBaseUri(), "item must have an associated URI"));
     return addItem(type, builder);
   }
 
-  protected <T> EntityItem addItem(@Nonnull ItemType type, @Nonnull IRequiredValueModelNodeItem item,
-      @Nonnull String identifier) {
+  protected <T> EntityItem addItem(@NonNull ItemType type, @NonNull IRequiredValueModelNodeItem item,
+      @NonNull String identifier) {
     EntityItem.Builder builder = EntityItem.builder()
-        .instance(item, identifier)
+        .instance(item, type, identifier)
         .source(ObjectUtils.requireNonNull(item.getBaseUri(), "item must have an associated URI"));
 
     return addItem(type, builder);
   }
 
-  protected EntityItem addItem(@Nonnull ItemType type, @Nonnull IRequiredValueModelNodeItem item,
-      @Nonnull String identifier,
-      @Nonnull String mappedIdentifier) {
+  protected EntityItem addItem(@NonNull ItemType type, @NonNull IRequiredValueModelNodeItem item,
+      @NonNull String identifier,
+      @NonNull String mappedIdentifier) {
 
     EntityItem.Builder builder = EntityItem.builder()
-        .instance(item, mappedIdentifier)
+        .instance(item, type, mappedIdentifier)
         .originalIdentifier(identifier)
         .source(ObjectUtils.requireNonNull(item.getBaseUri(), "item must have an associated URI"));
     return addItem(type, builder);
   }
 
-  protected <T> EntityItem addItem(@Nonnull ItemType type, @Nonnull EntityItem.Builder builder) {
-
-    builder
-        .itemType(type);
-
+  protected <T> EntityItem addItem(@NonNull ItemType type, @NonNull EntityItem.Builder builder) {
     return getIndex().addItem(builder.build());
   }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultIndexer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultIndexer.java
@@ -38,38 +38,38 @@ import gov.nist.secauto.oscal.lib.model.Party;
 import gov.nist.secauto.oscal.lib.model.Role;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.UUID;
 
 public class DefaultIndexer implements IIndexer {
-  @NotNull
+  @Nonnull
   private final Index index;
-  @NotNull
+  @Nonnull
   private final IIdentifierMapper mapper;
 
-  public DefaultIndexer(@NotNull IIdentifierMapper mapper) {
+  public DefaultIndexer(@Nonnull IIdentifierMapper mapper) {
     this(new Index(), mapper);
   }
 
-  public DefaultIndexer(@NotNull Index index, @NotNull IIdentifierMapper mapper) {
+  public DefaultIndexer(@Nonnull Index index, @Nonnull IIdentifierMapper mapper) {
     this.index = index;
     this.mapper = mapper;
   }
 
   @Override
-  @NotNull
+  @Nonnull
   public Index getIndex() {
     return index;
   }
 
-  @NotNull
+  @Nonnull
   protected IIdentifierMapper getMapper() {
     return mapper;
   }
 
   @Override
-  public EntityItem addRole(@NotNull IRequiredValueModelNodeItem item) {
+  public EntityItem addRole(@Nonnull IRequiredValueModelNodeItem item) {
     Role role = (Role) item.getValue();
     String identifier = ObjectUtils.notNull(role.getId());
     String mappedIdentifier = getMapper().mapRoleIdentifier(identifier);
@@ -84,7 +84,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addLocation(@NotNull IRequiredValueModelNodeItem item) {
+  public EntityItem addLocation(@Nonnull IRequiredValueModelNodeItem item) {
     Location location = (Location) item.getValue();
     UUID identifier = ObjectUtils.notNull(location.getUuid());
 
@@ -95,7 +95,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addParty(@NotNull IRequiredValueModelNodeItem item) {
+  public EntityItem addParty(@Nonnull IRequiredValueModelNodeItem item) {
     Party party = (Party) item.getValue();
     UUID identifier = ObjectUtils.notNull(party.getUuid());
 
@@ -106,7 +106,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addGroup(@NotNull IRequiredValueModelNodeItem item, boolean selected) {
+  public EntityItem addGroup(@Nonnull IRequiredValueModelNodeItem item, boolean selected) {
     CatalogGroup group = (CatalogGroup) item.getValue();
 
     if (selected) {
@@ -131,7 +131,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addControl(@NotNull IRequiredValueModelNodeItem item, boolean selected) {
+  public EntityItem addControl(@Nonnull IRequiredValueModelNodeItem item, boolean selected) {
     Control control = (Control) item.getValue();
     String identifier = ObjectUtils.notNull(control.getId());
     String mappedIdentifier = getMapper().mapControlIdentifier(identifier);
@@ -150,7 +150,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addParameter(@NotNull IRequiredValueModelNodeItem item) {
+  public EntityItem addParameter(@Nonnull IRequiredValueModelNodeItem item) {
     Parameter parameter = (Parameter) item.getValue();
     String identifier = ObjectUtils.notNull(parameter.getId());
     String mappedIdentifier = getMapper().mapParameterIdentifier(identifier);
@@ -165,7 +165,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addPart(@NotNull IRequiredValueModelNodeItem item) {
+  public EntityItem addPart(@Nonnull IRequiredValueModelNodeItem item) {
     ControlPart part = (ControlPart) item.getValue();
     String identifier = part.getId();
 
@@ -186,7 +186,7 @@ public class DefaultIndexer implements IIndexer {
   }
 
   @Override
-  public EntityItem addResource(@NotNull IRequiredValueModelNodeItem item) {
+  public EntityItem addResource(@Nonnull IRequiredValueModelNodeItem item) {
     Resource resource = (Resource) item.getValue();
     UUID identifier = ObjectUtils.notNull(resource.getUuid());
 
@@ -196,16 +196,16 @@ public class DefaultIndexer implements IIndexer {
         identifier);
   }
 
-  protected <T> EntityItem addItem(@NotNull ItemType type, @NotNull IRequiredValueModelNodeItem item,
-      @NotNull UUID identifier) {
+  protected <T> EntityItem addItem(@Nonnull ItemType type, @Nonnull IRequiredValueModelNodeItem item,
+      @Nonnull UUID identifier) {
     EntityItem.Builder builder = EntityItem.builder()
         .instance(item, identifier)
         .source(ObjectUtils.requireNonNull(item.getBaseUri(), "item must have an associated URI"));
     return addItem(type, builder);
   }
 
-  protected <T> EntityItem addItem(@NotNull ItemType type, @NotNull IRequiredValueModelNodeItem item,
-      @NotNull String identifier) {
+  protected <T> EntityItem addItem(@Nonnull ItemType type, @Nonnull IRequiredValueModelNodeItem item,
+      @Nonnull String identifier) {
     EntityItem.Builder builder = EntityItem.builder()
         .instance(item, identifier)
         .source(ObjectUtils.requireNonNull(item.getBaseUri(), "item must have an associated URI"));
@@ -213,9 +213,9 @@ public class DefaultIndexer implements IIndexer {
     return addItem(type, builder);
   }
 
-  protected EntityItem addItem(@NotNull ItemType type, @NotNull IRequiredValueModelNodeItem item,
-      @NotNull String identifier,
-      @NotNull String mappedIdentifier) {
+  protected EntityItem addItem(@Nonnull ItemType type, @Nonnull IRequiredValueModelNodeItem item,
+      @Nonnull String identifier,
+      @Nonnull String mappedIdentifier) {
 
     EntityItem.Builder builder = EntityItem.builder()
         .instance(item, mappedIdentifier)
@@ -224,7 +224,7 @@ public class DefaultIndexer implements IIndexer {
     return addItem(type, builder);
   }
 
-  protected <T> EntityItem addItem(@NotNull ItemType type, @NotNull EntityItem.Builder builder) {
+  protected <T> EntityItem addItem(@Nonnull ItemType type, @Nonnull EntityItem.Builder builder) {
 
     builder
         .itemType(type);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultResult.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultResult.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.oscal.lib.model.Parameter;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -44,12 +44,12 @@ import java.util.Set;
 public class DefaultResult implements IResult {
   private static final Logger LOGGER = LogManager.getLogger(DefaultResult.class);
 
-  @NotNull
-  private final Set<@NotNull Parameter> promotedParameters;
-  @NotNull
-  private final Set<@NotNull Control> promotedControls;
-  @NotNull
-  private final Set<@NotNull String> requiredParameterIds;
+  @Nonnull
+  private final Set<@Nonnull Parameter> promotedParameters;
+  @Nonnull
+  private final Set<@Nonnull Control> promotedControls;
+  @Nonnull
+  private final Set<@Nonnull String> requiredParameterIds;
 
   public DefaultResult() {
     this.promotedParameters = new LinkedHashSet<>();
@@ -58,35 +58,35 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  @NotNull
-  public Collection<@NotNull Parameter> getPromotedParameters() {
+  @Nonnull
+  public Collection<@Nonnull Parameter> getPromotedParameters() {
     return promotedParameters;
   }
 
   @Override
-  @NotNull
-  public Collection<@NotNull Control> getPromotedControls() {
+  @Nonnull
+  public Collection<@Nonnull Control> getPromotedControls() {
     return promotedControls;
   }
 
   @Override
-  @NotNull
-  public Set<@NotNull String> getRequiredParameterIds() {
+  @Nonnull
+  public Set<@Nonnull String> getRequiredParameterIds() {
     return CollectionUtil.unmodifiableSet(requiredParameterIds);
   }
 
   @Override
-  public void requireParameters(@NotNull Set<@NotNull String> requiredParameterIds) {
+  public void requireParameters(@Nonnull Set<@Nonnull String> requiredParameterIds) {
     this.requiredParameterIds.addAll(requiredParameterIds);
   }
 
   @Override
-  public boolean isParameterRequired(@NotNull String id) {
+  public boolean isParameterRequired(@Nonnull String id) {
     return getRequiredParameterIds().contains(id);
   }
 
   @Override
-  public void promoteParameter(@NotNull Parameter param) {
+  public void promoteParameter(@Nonnull Parameter param) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("promoting parameter '{}'", param.getId());
     }
@@ -94,7 +94,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void promoteControl(@NotNull Control control) {
+  public void promoteControl(@Nonnull Control control) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("promoting control '{}'", control.getId());
     }
@@ -102,7 +102,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void applyTo(@NotNull Catalog parent) {
+  public void applyTo(@Nonnull Catalog parent) {
     getPromotedParameters().forEach(param -> parent.addParam(param));
     getPromotedControls().forEach(control -> {
       parent.addControl(control);
@@ -111,7 +111,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void applyTo(@NotNull CatalogGroup parent) {
+  public void applyTo(@Nonnull CatalogGroup parent) {
     getPromotedParameters().forEach(param -> parent.addParam(param));
     getPromotedControls().forEach(control -> {
       parent.addControl(control);
@@ -120,7 +120,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void applyTo(@NotNull Control parent) {
+  public void applyTo(@Nonnull Control parent) {
     getPromotedParameters().forEach(param -> parent.addParam(param));
     getPromotedControls().forEach(control -> {
       parent.addControl(control);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultResult.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultResult.java
@@ -34,22 +34,24 @@ import gov.nist.secauto.oscal.lib.model.Parameter;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class DefaultResult implements IResult {
   private static final Logger LOGGER = LogManager.getLogger(DefaultResult.class);
 
-  @Nonnull
-  private final Set<@Nonnull Parameter> promotedParameters;
-  @Nonnull
-  private final Set<@Nonnull Control> promotedControls;
-  @Nonnull
-  private final Set<@Nonnull String> requiredParameterIds;
+  @NonNull
+  private final Set<Parameter> promotedParameters;
+  @NonNull
+  private final Set<Control> promotedControls;
+  @NonNull
+  private final Set<String> requiredParameterIds;
 
   public DefaultResult() {
     this.promotedParameters = new LinkedHashSet<>();
@@ -58,35 +60,37 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  @Nonnull
-  public Collection<@Nonnull Parameter> getPromotedParameters() {
+  @NonNull
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intending to expose this field")
+  public Collection<Parameter> getPromotedParameters() {
     return promotedParameters;
   }
 
   @Override
-  @Nonnull
-  public Collection<@Nonnull Control> getPromotedControls() {
+  @NonNull
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intending to expose this field")
+  public Collection<Control> getPromotedControls() {
     return promotedControls;
   }
 
   @Override
-  @Nonnull
-  public Set<@Nonnull String> getRequiredParameterIds() {
+  @NonNull
+  public Set<String> getRequiredParameterIds() {
     return CollectionUtil.unmodifiableSet(requiredParameterIds);
   }
 
   @Override
-  public void requireParameters(@Nonnull Set<@Nonnull String> requiredParameterIds) {
+  public void requireParameters(@NonNull Set<String> requiredParameterIds) {
     this.requiredParameterIds.addAll(requiredParameterIds);
   }
 
   @Override
-  public boolean isParameterRequired(@Nonnull String id) {
+  public boolean isParameterRequired(@NonNull String id) {
     return getRequiredParameterIds().contains(id);
   }
 
   @Override
-  public void promoteParameter(@Nonnull Parameter param) {
+  public void promoteParameter(@NonNull Parameter param) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("promoting parameter '{}'", param.getId());
     }
@@ -94,7 +98,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void promoteControl(@Nonnull Control control) {
+  public void promoteControl(@NonNull Control control) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("promoting control '{}'", control.getId());
     }
@@ -102,7 +106,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void applyTo(@Nonnull Catalog parent) {
+  public void applyTo(@NonNull Catalog parent) {
     getPromotedParameters().forEach(param -> parent.addParam(param));
     getPromotedControls().forEach(control -> {
       parent.addControl(control);
@@ -111,7 +115,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void applyTo(@Nonnull CatalogGroup parent) {
+  public void applyTo(@NonNull CatalogGroup parent) {
     getPromotedParameters().forEach(param -> parent.addParam(param));
     getPromotedControls().forEach(control -> {
       parent.addControl(control);
@@ -120,7 +124,7 @@ public class DefaultResult implements IResult {
   }
 
   @Override
-  public void applyTo(@Nonnull Control parent) {
+  public void applyTo(@NonNull Control parent) {
     getPromotedParameters().forEach(param -> parent.addParam(param));
     getPromotedControls().forEach(control -> {
       parent.addControl(control);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/EntityItem.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/EntityItem.java
@@ -35,7 +35,7 @@ import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControlContainer;
 import gov.nist.secauto.oscal.lib.profile.resolver.policy.IReferenceVisitor;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.Objects;
@@ -56,15 +56,15 @@ public final class EntityItem {
     RESOURCE;
   }
 
-  @NotNull
+  @Nonnull
   private final String originalIdentifier;
-  @NotNull
+  @Nonnull
   private final String identifier;
-  @NotNull
+  @Nonnull
   private final IRequiredValueModelNodeItem instance;
-  @NotNull
+  @Nonnull
   private final ItemType itemType;
-  @NotNull
+  @Nonnull
   private final URI source;
   private int referenceCount; // 0 by default
   private boolean resolved; // false by default
@@ -74,7 +74,7 @@ public final class EntityItem {
   }
 
   @SuppressWarnings("null")
-  private EntityItem(@NotNull Builder builder) {
+  private EntityItem(@Nonnull Builder builder) {
     this.originalIdentifier = builder.originalIdentifier == null ? builder.identifier : builder.originalIdentifier;
     this.identifier = Objects.requireNonNull(builder.identifier, "identifier");
     this.instance = Objects.requireNonNull(builder.instance, "instance");
@@ -82,33 +82,33 @@ public final class EntityItem {
     this.source = Objects.requireNonNull(builder.source, "source");
   }
 
-  @NotNull
+  @Nonnull
   public String getOriginalIdentifier() {
     return originalIdentifier;
   }
 
-  @NotNull
+  @Nonnull
   public String getIdentifier() {
     return identifier;
   }
 
-  @NotNull
+  @Nonnull
   public IRequiredValueModelNodeItem getInstance() {
     return instance;
   }
 
-  @NotNull
+  @Nonnull
   @SuppressWarnings("unchecked")
   public <T> T getInstanceValue() {
     return (T) instance.getValue();
   }
 
-  @NotNull
+  @Nonnull
   public ItemType getItemType() {
     return itemType;
   }
 
-  @NotNull
+  @Nonnull
   public URI getSource() {
     return source;
   }
@@ -133,7 +133,7 @@ public final class EntityItem {
     referenceCount += 1;
   }
 
-  public boolean isSelected(@NotNull Index index) {
+  public boolean isSelected(@Nonnull Index index) {
     boolean retval;
     switch (getItemType()) {
     case CONTROL:
@@ -164,7 +164,7 @@ public final class EntityItem {
     return retval;
   }
 
-  public void accept(@NotNull IReferenceVisitor visitor) {
+  public void accept(@Nonnull IReferenceVisitor visitor) {
     IRequiredValueModelNodeItem instance = getInstance();
     switch (getItemType()) {
     case CONTROL:
@@ -203,33 +203,33 @@ public final class EntityItem {
     private ItemType itemType;
     private URI source;
 
-    public Builder instance(@NotNull IRequiredValueModelNodeItem item, @NotNull UUID identifier) {
+    public Builder instance(@Nonnull IRequiredValueModelNodeItem item, @Nonnull UUID identifier) {
       return instance(item, ObjectUtils.notNull(identifier.toString()));
     }
 
     @SuppressWarnings("null")
-    public Builder instance(@NotNull IRequiredValueModelNodeItem item, @NotNull String identifier) {
+    public Builder instance(@Nonnull IRequiredValueModelNodeItem item, @Nonnull String identifier) {
       this.identifier = Objects.requireNonNull(identifier, "identifier");
       this.instance = Objects.requireNonNull(item, "item");
       return this;
     }
 
-    public Builder originalIdentifier(@NotNull String identifier) {
+    public Builder originalIdentifier(@Nonnull String identifier) {
       this.originalIdentifier = identifier;
       return this;
     }
 
-    public Builder itemType(@NotNull ItemType itemType) {
+    public Builder itemType(@Nonnull ItemType itemType) {
       this.itemType = itemType;
       return this;
     }
 
-    public Builder source(@NotNull URI source) {
+    public Builder source(@Nonnull URI source) {
       this.source = source;
       return this;
     }
 
-    @NotNull
+    @Nonnull
     public EntityItem build() {
       return new EntityItem(this);
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/EntityItem.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/EntityItem.java
@@ -26,6 +26,7 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver;
 
+import gov.nist.secauto.metaschema.model.common.datatype.adapter.UuidAdapter;
 import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression;
 import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression.ResultType;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
@@ -35,11 +36,12 @@ import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControlContainer;
 import gov.nist.secauto.oscal.lib.profile.resolver.policy.IReferenceVisitor;
 
-import javax.annotation.Nonnull;
-
 import java.net.URI;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class EntityItem {
   private static final MetapathExpression CONTAINER_METAPATH
@@ -56,15 +58,15 @@ public final class EntityItem {
     RESOURCE;
   }
 
-  @Nonnull
+  @NonNull
   private final String originalIdentifier;
-  @Nonnull
+  @NonNull
   private final String identifier;
-  @Nonnull
+  @NonNull
   private final IRequiredValueModelNodeItem instance;
-  @Nonnull
+  @NonNull
   private final ItemType itemType;
-  @Nonnull
+  @NonNull
   private final URI source;
   private int referenceCount; // 0 by default
   private boolean resolved; // false by default
@@ -73,8 +75,7 @@ public final class EntityItem {
     return new Builder();
   }
 
-  @SuppressWarnings("null")
-  private EntityItem(@Nonnull Builder builder) {
+  private EntityItem(@NonNull Builder builder) {
     this.originalIdentifier = builder.originalIdentifier == null ? builder.identifier : builder.originalIdentifier;
     this.identifier = Objects.requireNonNull(builder.identifier, "identifier");
     this.instance = Objects.requireNonNull(builder.instance, "instance");
@@ -82,33 +83,33 @@ public final class EntityItem {
     this.source = Objects.requireNonNull(builder.source, "source");
   }
 
-  @Nonnull
+  @NonNull
   public String getOriginalIdentifier() {
     return originalIdentifier;
   }
 
-  @Nonnull
+  @NonNull
   public String getIdentifier() {
     return identifier;
   }
 
-  @Nonnull
+  @NonNull
   public IRequiredValueModelNodeItem getInstance() {
     return instance;
   }
 
-  @Nonnull
+  @NonNull
   @SuppressWarnings("unchecked")
   public <T> T getInstanceValue() {
     return (T) instance.getValue();
   }
 
-  @Nonnull
+  @NonNull
   public ItemType getItemType() {
     return itemType;
   }
 
-  @Nonnull
+  @NonNull
   public URI getSource() {
     return source;
   }
@@ -133,7 +134,7 @@ public final class EntityItem {
     referenceCount += 1;
   }
 
-  public boolean isSelected(@Nonnull Index index) {
+  public boolean isSelected(@NonNull Index index) {
     boolean retval;
     switch (getItemType()) {
     case CONTROL:
@@ -159,12 +160,12 @@ public final class EntityItem {
       retval = true;
       break;
     default:
-      throw new IllegalStateException(getItemType().name());
+      throw new UnsupportedOperationException(getItemType().name());
     }
     return retval;
   }
 
-  public void accept(@Nonnull IReferenceVisitor visitor) {
+  public void accept(@NonNull IReferenceVisitor visitor) {
     IRequiredValueModelNodeItem instance = getInstance();
     switch (getItemType()) {
     case CONTROL:
@@ -192,44 +193,61 @@ public final class EntityItem {
       visitor.visitRole(instance);
       break;
     default:
-      throw new IllegalStateException(getItemType().name());
+      throw new UnsupportedOperationException(getItemType().name());
     }
   }
 
+  @NonNull
+  public static String normalizeIdentifier(@NonNull ItemType type, @NonNull String identifier) {
+    String retval = identifier;
+    switch (type) {
+    case LOCATION:
+    case PARTY:
+    case RESOURCE:
+      if (UuidAdapter.UUID_PATTERN.matches(identifier)) {
+        // normalize the UUID
+        retval = identifier.toLowerCase(Locale.ROOT);
+      }
+      break;
+    default:
+      // do nothing
+      break;
+    }
+
+    return retval;
+  }
+
   public static class Builder {
-    private String originalIdentifier;
+    private String originalIdentifier; // NOPMD - builder method
     private String identifier;
-    private IRequiredValueModelNodeItem instance;
+    private IRequiredValueModelNodeItem instance; // NOPMD - builder method
     private ItemType itemType;
-    private URI source;
+    private URI source; // NOPMD - builder method
 
-    public Builder instance(@Nonnull IRequiredValueModelNodeItem item, @Nonnull UUID identifier) {
-      return instance(item, ObjectUtils.notNull(identifier.toString()));
+    public Builder instance(@NonNull IRequiredValueModelNodeItem item, @NonNull ItemType itemType,
+        @NonNull UUID identifier) {
+      return instance(item, itemType, ObjectUtils.notNull(identifier.toString()));
     }
 
-    @SuppressWarnings("null")
-    public Builder instance(@Nonnull IRequiredValueModelNodeItem item, @Nonnull String identifier) {
-      this.identifier = Objects.requireNonNull(identifier, "identifier");
+    public Builder instance(@NonNull IRequiredValueModelNodeItem item, @NonNull ItemType itemType,
+        @NonNull String identifier) {
+      this.identifier = normalizeIdentifier(itemType, ObjectUtils.requireNonNull(identifier, "identifier"));
       this.instance = Objects.requireNonNull(item, "item");
-      return this;
-    }
-
-    public Builder originalIdentifier(@Nonnull String identifier) {
-      this.originalIdentifier = identifier;
-      return this;
-    }
-
-    public Builder itemType(@Nonnull ItemType itemType) {
       this.itemType = itemType;
       return this;
     }
 
-    public Builder source(@Nonnull URI source) {
+    public Builder originalIdentifier(@NonNull String identifier) {
+      this.originalIdentifier = normalizeIdentifier(itemType, identifier);
+      return this;
+    }
+
+    public Builder source(@NonNull URI source) {
       this.source = source;
       return this;
     }
 
-    @Nonnull
+    @NonNull
     public EntityItem build() {
       return new EntityItem(this);
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FilterNonSelectedVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FilterNonSelectedVisitor.java
@@ -46,24 +46,24 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public class FilterNonSelectedVisitor {
   private static final Logger LOGGER = LogManager.getLogger(FilterNonSelectedVisitor.class);
 
-  @NotNull
+  @Nonnull
   private final Index index;
 
-  public FilterNonSelectedVisitor(@NotNull Index index) {
+  public FilterNonSelectedVisitor(@Nonnull Index index) {
     this.index = index;
   }
 
-  @NotNull
+  @Nonnull
   protected Index getIndex() {
     return index;
   }
 
-  public void visitCatalog(@NotNull IDocumentNodeItem catalogItem) {
+  public void visitCatalog(@Nonnull IDocumentNodeItem catalogItem) {
     IRootAssemblyNodeItem root = catalogItem.getRootAssemblyNodeItem();
 
     Catalog catalog = (Catalog) catalogItem.getValue();
@@ -154,7 +154,7 @@ public class FilterNonSelectedVisitor {
         });
   }
 
-  @NotNull
+  @Nonnull
   protected IResult visitGroup(IRequiredValueModelNodeItem item, IGroupContainer container) {
 
     CatalogGroup group = (CatalogGroup) item.getValue();
@@ -206,7 +206,7 @@ public class FilterNonSelectedVisitor {
     return retval;
   }
 
-  @NotNull
+  @Nonnull
   protected IResult visitControl(IRequiredValueModelNodeItem item, IControlContainer container) {
     Control control = (Control) item.getValue();
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FilterNonSelectedVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FilterNonSelectedVisitor.java
@@ -46,24 +46,27 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class FilterNonSelectedVisitor {
   private static final Logger LOGGER = LogManager.getLogger(FilterNonSelectedVisitor.class);
 
-  @Nonnull
+  @NonNull
   private final Index index;
 
-  public FilterNonSelectedVisitor(@Nonnull Index index) {
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intending to store this parameter")
+  public FilterNonSelectedVisitor(@NonNull Index index) {
     this.index = index;
   }
 
-  @Nonnull
+  @NonNull
   protected Index getIndex() {
     return index;
   }
 
-  public void visitCatalog(@Nonnull IDocumentNodeItem catalogItem) {
+  public void visitCatalog(@NonNull IDocumentNodeItem catalogItem) {
     IRootAssemblyNodeItem root = catalogItem.getRootAssemblyNodeItem();
 
     Catalog catalog = (Catalog) catalogItem.getValue();
@@ -154,7 +157,7 @@ public class FilterNonSelectedVisitor {
         });
   }
 
-  @Nonnull
+  @NonNull
   protected IResult visitGroup(IRequiredValueModelNodeItem item, IGroupContainer container) {
 
     CatalogGroup group = (CatalogGroup) item.getValue();
@@ -206,7 +209,7 @@ public class FilterNonSelectedVisitor {
     return retval;
   }
 
-  @Nonnull
+  @NonNull
   protected IResult visitControl(IRequiredValueModelNodeItem item, IControlContainer container) {
     Control control = (Control) item.getValue();
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FlatStructureCatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FlatStructureCatalogVisitor.java
@@ -32,19 +32,19 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Iterator;
 import java.util.List;
 
 public class FlatStructureCatalogVisitor {
 
-  public void visitCatalog(@Nonnull Catalog catalog) {
+  public void visitCatalog(@NonNull Catalog catalog) {
     DefaultResult result = new DefaultResult();
     // process children
     for (Iterator<CatalogGroup> iter = CollectionUtil.listOrEmpty(catalog.getGroups()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @Nonnull
+      @NonNull
       CatalogGroup child = iter.next();
       DefaultResult childResult = visitGroup(child);
 
@@ -55,7 +55,7 @@ public class FlatStructureCatalogVisitor {
 
     for (Iterator<Control> iter = CollectionUtil.listOrEmpty(catalog.getControls()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @Nonnull
+      @NonNull
       Control child = iter.next();
       DefaultResult childResult = visitControl(child);
 
@@ -65,15 +65,15 @@ public class FlatStructureCatalogVisitor {
     result.applyTo(catalog);
   }
 
-  @Nonnull
-  public DefaultResult visitGroup(@Nonnull CatalogGroup group) {
+  @NonNull
+  public DefaultResult visitGroup(@NonNull CatalogGroup group) {
     // process children
     DefaultResult retval = new DefaultResult();
 
     // groups
     for (Iterator<CatalogGroup> iter = CollectionUtil.listOrEmpty(group.getGroups()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @Nonnull
+      @NonNull
       CatalogGroup child = iter.next();
       DefaultResult result = visitGroup(child);
       retval.append(result);
@@ -81,14 +81,14 @@ public class FlatStructureCatalogVisitor {
 
     for (Iterator<Parameter> iter = CollectionUtil.listOrEmpty(group.getParams()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @Nonnull
+      @NonNull
       Parameter child = iter.next();
       retval.promoteParameter(child);
     }
 
     for (Iterator<Control> iter = CollectionUtil.listOrEmpty(group.getControls()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @Nonnull
+      @NonNull
       Control child = iter.next();
       retval.promoteControl(child);
       DefaultResult result = visitControl(child);
@@ -98,8 +98,8 @@ public class FlatStructureCatalogVisitor {
     return retval;
   }
 
-  @Nonnull
-  public DefaultResult visitControl(@Nonnull Control control) {
+  @NonNull
+  public DefaultResult visitControl(@NonNull Control control) {
     DefaultResult result = new DefaultResult();
 
     List<Control> controlChildren = CollectionUtil.listOrEmpty(control.getControls());
@@ -107,7 +107,7 @@ public class FlatStructureCatalogVisitor {
 
       for (Iterator<Control> iter = CollectionUtil.listOrEmpty(control.getControls()).iterator(); iter.hasNext();) {
         @SuppressWarnings("null")
-        @Nonnull
+        @NonNull
         Control child = iter.next();
         DefaultResult childResult = visitControl(child);
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FlatStructureCatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/FlatStructureCatalogVisitor.java
@@ -32,19 +32,19 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Iterator;
 import java.util.List;
 
 public class FlatStructureCatalogVisitor {
 
-  public void visitCatalog(@NotNull Catalog catalog) {
+  public void visitCatalog(@Nonnull Catalog catalog) {
     DefaultResult result = new DefaultResult();
     // process children
     for (Iterator<CatalogGroup> iter = CollectionUtil.listOrEmpty(catalog.getGroups()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @NotNull
+      @Nonnull
       CatalogGroup child = iter.next();
       DefaultResult childResult = visitGroup(child);
 
@@ -55,7 +55,7 @@ public class FlatStructureCatalogVisitor {
 
     for (Iterator<Control> iter = CollectionUtil.listOrEmpty(catalog.getControls()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @NotNull
+      @Nonnull
       Control child = iter.next();
       DefaultResult childResult = visitControl(child);
 
@@ -65,15 +65,15 @@ public class FlatStructureCatalogVisitor {
     result.applyTo(catalog);
   }
 
-  @NotNull
-  public DefaultResult visitGroup(@NotNull CatalogGroup group) {
+  @Nonnull
+  public DefaultResult visitGroup(@Nonnull CatalogGroup group) {
     // process children
     DefaultResult retval = new DefaultResult();
 
     // groups
     for (Iterator<CatalogGroup> iter = CollectionUtil.listOrEmpty(group.getGroups()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @NotNull
+      @Nonnull
       CatalogGroup child = iter.next();
       DefaultResult result = visitGroup(child);
       retval.append(result);
@@ -81,14 +81,14 @@ public class FlatStructureCatalogVisitor {
 
     for (Iterator<Parameter> iter = CollectionUtil.listOrEmpty(group.getParams()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @NotNull
+      @Nonnull
       Parameter child = iter.next();
       retval.promoteParameter(child);
     }
 
     for (Iterator<Control> iter = CollectionUtil.listOrEmpty(group.getControls()).iterator(); iter.hasNext();) {
       @SuppressWarnings("null")
-      @NotNull
+      @Nonnull
       Control child = iter.next();
       retval.promoteControl(child);
       DefaultResult result = visitControl(child);
@@ -98,8 +98,8 @@ public class FlatStructureCatalogVisitor {
     return retval;
   }
 
-  @NotNull
-  public DefaultResult visitControl(@NotNull Control control) {
+  @Nonnull
+  public DefaultResult visitControl(@Nonnull Control control) {
     DefaultResult result = new DefaultResult();
 
     List<Control> controlChildren = CollectionUtil.listOrEmpty(control.getControls());
@@ -107,7 +107,7 @@ public class FlatStructureCatalogVisitor {
 
       for (Iterator<Control> iter = CollectionUtil.listOrEmpty(control.getControls()).iterator(); iter.hasNext();) {
         @SuppressWarnings("null")
-        @NotNull
+        @Nonnull
         Control child = iter.next();
         DefaultResult childResult = visitControl(child);
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlFilter.java
@@ -33,44 +33,44 @@ import gov.nist.secauto.oscal.lib.model.control.catalog.IControl;
 import gov.nist.secauto.oscal.lib.model.control.profile.IProfileSelectControlById;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 
 public interface IControlFilter {
-  @NotNull
+  @Nonnull
   IControlFilter ALWAYS_MATCH = new IControlFilter() {
     @Override
-    public @NotNull Pair<@NotNull Boolean, @NotNull Boolean> match(@NotNull IControl control, boolean defaultMatch) {
+    public @Nonnull Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch) {
       return IControlSelectionFilter.MATCH;
     }
 
     @Override
-    public @NotNull IControlSelectionFilter getInclusionFilter() {
+    public @Nonnull IControlSelectionFilter getInclusionFilter() {
       return IControlSelectionFilter.ALL_MATCH;
     }
 
     @Override
-    public @NotNull IControlSelectionFilter getExclusionFilter() {
+    public @Nonnull IControlSelectionFilter getExclusionFilter() {
       return IControlSelectionFilter.NONE_MATCH;
     }
   };
 
-  @NotNull
+  @Nonnull
   IControlFilter NONE_MATCH = new IControlFilter() {
 
     @Override
-    public @NotNull Pair<@NotNull Boolean, @NotNull Boolean> match(@NotNull IControl control, boolean defaultMatch) {
+    public @Nonnull Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch) {
       return IControlSelectionFilter.NON_MATCH;
     }
 
     @Override
-    public @NotNull IControlSelectionFilter getInclusionFilter() {
+    public @Nonnull IControlSelectionFilter getInclusionFilter() {
       return IControlSelectionFilter.NONE_MATCH;
     }
 
     @Override
-    public @NotNull IControlSelectionFilter getExclusionFilter() {
+    public @Nonnull IControlSelectionFilter getExclusionFilter() {
       return IControlSelectionFilter.NONE_MATCH;
     }
   };
@@ -82,14 +82,14 @@ public interface IControlFilter {
    *          an OSCAL profile import statement
    * @return a new control filter
    */
-  @NotNull
-  static IControlFilter newInstance(@NotNull ProfileImport profileImport) {
+  @Nonnull
+  static IControlFilter newInstance(@Nonnull ProfileImport profileImport) {
     return new Filter(profileImport);
   }
 
-  @NotNull
-  static IControlFilter newInstance(@NotNull IControlSelectionFilter includes,
-      @NotNull IControlSelectionFilter excludes) {
+  @Nonnull
+  static IControlFilter newInstance(@Nonnull IControlSelectionFilter includes,
+      @Nonnull IControlSelectionFilter excludes) {
     return new Filter(includes, excludes);
   }
 
@@ -103,8 +103,8 @@ public interface IControlFilter {
    * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
    *         otherwise), and if a match applies to child controls
    */
-  @NotNull
-  default Pair<@NotNull Boolean, @NotNull Boolean> match(@NotNull IControl control) {
+  @Nonnull
+  default Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control) {
     return match(control, false);
   }
 
@@ -120,22 +120,22 @@ public interface IControlFilter {
    * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
    *         otherwise), and if a match applies to child controls
    */
-  @NotNull
-  Pair<@NotNull Boolean, @NotNull Boolean> match(@NotNull IControl control, boolean defaultMatch);
+  @Nonnull
+  Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch);
 
-  @NotNull
+  @Nonnull
   IControlSelectionFilter getInclusionFilter();
 
-  @NotNull
+  @Nonnull
   IControlSelectionFilter getExclusionFilter();
 
   class Filter implements IControlFilter {
-    @NotNull
+    @Nonnull
     private final IControlSelectionFilter inclusionFilter;
-    @NotNull
+    @Nonnull
     private final IControlSelectionFilter exclusionFilter;
 
-    public Filter(@NotNull ProfileImport profileImport) {
+    public Filter(@Nonnull ProfileImport profileImport) {
       IncludeAll includeAll = profileImport.getIncludeAll();
 
       if (includeAll == null) {
@@ -158,31 +158,31 @@ public interface IControlFilter {
 
     }
 
-    public Filter(@NotNull IControlSelectionFilter includes, @NotNull IControlSelectionFilter excludes) {
+    public Filter(@Nonnull IControlSelectionFilter includes, @Nonnull IControlSelectionFilter excludes) {
       this.inclusionFilter = includes;
       this.exclusionFilter = excludes;
     }
 
     @Override
-    @NotNull
+    @Nonnull
     public IControlSelectionFilter getInclusionFilter() {
       return inclusionFilter;
     }
 
     @Override
-    @NotNull
+    @Nonnull
     public IControlSelectionFilter getExclusionFilter() {
       return exclusionFilter;
     }
 
     @Override
-    public Pair<@NotNull Boolean, @NotNull Boolean> match(@NotNull IControl control, boolean defaultMatch) {
-      @NotNull
-      Pair<@NotNull Boolean, @NotNull Boolean> result = getInclusionFilter().apply(control);
+    public Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch) {
+      @Nonnull
+      Pair<@Nonnull Boolean, @Nonnull Boolean> result = getInclusionFilter().apply(control);
       boolean left = ObjectUtils.notNull(result.getLeft());
       if (left) {
         // this is a positive include match. Is it excluded?
-        Pair<@NotNull Boolean, @NotNull Boolean> excluded = getExclusionFilter().apply(control);
+        Pair<@Nonnull Boolean, @Nonnull Boolean> excluded = getExclusionFilter().apply(control);
         if (ObjectUtils.notNull(excluded.getLeft())) {
           // the effective result is a non-match
           result = IControlSelectionFilter.NON_MATCH;

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlFilter.java
@@ -33,44 +33,45 @@ import gov.nist.secauto.oscal.lib.model.control.catalog.IControl;
 import gov.nist.secauto.oscal.lib.model.control.profile.IProfileSelectControlById;
 
 import org.apache.commons.lang3.tuple.Pair;
-import javax.annotation.Nonnull;
 
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public interface IControlFilter {
-  @Nonnull
+  @NonNull
   IControlFilter ALWAYS_MATCH = new IControlFilter() {
     @Override
-    public @Nonnull Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch) {
+    public @NonNull Pair<Boolean, Boolean> match(@NonNull IControl control, boolean defaultMatch) {
       return IControlSelectionFilter.MATCH;
     }
 
     @Override
-    public @Nonnull IControlSelectionFilter getInclusionFilter() {
+    public @NonNull IControlSelectionFilter getInclusionFilter() {
       return IControlSelectionFilter.ALL_MATCH;
     }
 
     @Override
-    public @Nonnull IControlSelectionFilter getExclusionFilter() {
+    public @NonNull IControlSelectionFilter getExclusionFilter() {
       return IControlSelectionFilter.NONE_MATCH;
     }
   };
 
-  @Nonnull
+  @NonNull
   IControlFilter NONE_MATCH = new IControlFilter() {
 
     @Override
-    public @Nonnull Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch) {
+    public @NonNull Pair<Boolean, Boolean> match(@NonNull IControl control, boolean defaultMatch) {
       return IControlSelectionFilter.NON_MATCH;
     }
 
     @Override
-    public @Nonnull IControlSelectionFilter getInclusionFilter() {
+    public @NonNull IControlSelectionFilter getInclusionFilter() {
       return IControlSelectionFilter.NONE_MATCH;
     }
 
     @Override
-    public @Nonnull IControlSelectionFilter getExclusionFilter() {
+    public @NonNull IControlSelectionFilter getExclusionFilter() {
       return IControlSelectionFilter.NONE_MATCH;
     }
   };
@@ -82,14 +83,14 @@ public interface IControlFilter {
    *          an OSCAL profile import statement
    * @return a new control filter
    */
-  @Nonnull
-  static IControlFilter newInstance(@Nonnull ProfileImport profileImport) {
+  @NonNull
+  static IControlFilter newInstance(@NonNull ProfileImport profileImport) {
     return new Filter(profileImport);
   }
 
-  @Nonnull
-  static IControlFilter newInstance(@Nonnull IControlSelectionFilter includes,
-      @Nonnull IControlSelectionFilter excludes) {
+  @NonNull
+  static IControlFilter newInstance(@NonNull IControlSelectionFilter includes,
+      @NonNull IControlSelectionFilter excludes) {
     return new Filter(includes, excludes);
   }
 
@@ -103,8 +104,8 @@ public interface IControlFilter {
    * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
    *         otherwise), and if a match applies to child controls
    */
-  @Nonnull
-  default Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control) {
+  @NonNull
+  default Pair<Boolean, Boolean> match(@NonNull IControl control) {
     return match(control, false);
   }
 
@@ -120,22 +121,22 @@ public interface IControlFilter {
    * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
    *         otherwise), and if a match applies to child controls
    */
-  @Nonnull
-  Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch);
+  @NonNull
+  Pair<Boolean, Boolean> match(@NonNull IControl control, boolean defaultMatch);
 
-  @Nonnull
+  @NonNull
   IControlSelectionFilter getInclusionFilter();
 
-  @Nonnull
+  @NonNull
   IControlSelectionFilter getExclusionFilter();
 
   class Filter implements IControlFilter {
-    @Nonnull
+    @NonNull
     private final IControlSelectionFilter inclusionFilter;
-    @Nonnull
+    @NonNull
     private final IControlSelectionFilter exclusionFilter;
 
-    public Filter(@Nonnull ProfileImport profileImport) {
+    public Filter(@NonNull ProfileImport profileImport) {
       IncludeAll includeAll = profileImport.getIncludeAll();
 
       if (includeAll == null) {
@@ -158,31 +159,31 @@ public interface IControlFilter {
 
     }
 
-    public Filter(@Nonnull IControlSelectionFilter includes, @Nonnull IControlSelectionFilter excludes) {
+    public Filter(@NonNull IControlSelectionFilter includes, @NonNull IControlSelectionFilter excludes) {
       this.inclusionFilter = includes;
       this.exclusionFilter = excludes;
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public IControlSelectionFilter getInclusionFilter() {
       return inclusionFilter;
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public IControlSelectionFilter getExclusionFilter() {
       return exclusionFilter;
     }
 
     @Override
-    public Pair<@Nonnull Boolean, @Nonnull Boolean> match(@Nonnull IControl control, boolean defaultMatch) {
-      @Nonnull
-      Pair<@Nonnull Boolean, @Nonnull Boolean> result = getInclusionFilter().apply(control);
+    public Pair<Boolean, Boolean> match(@NonNull IControl control, boolean defaultMatch) {
+      @NonNull
+      Pair<Boolean, Boolean> result = getInclusionFilter().apply(control);
       boolean left = ObjectUtils.notNull(result.getLeft());
       if (left) {
         // this is a positive include match. Is it excluded?
-        Pair<@Nonnull Boolean, @Nonnull Boolean> excluded = getExclusionFilter().apply(control);
+        Pair<Boolean, Boolean> excluded = getExclusionFilter().apply(control);
         if (ObjectUtils.notNull(excluded.getLeft())) {
           // the effective result is a non-match
           result = IControlSelectionFilter.NON_MATCH;

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlSelectionFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlSelectionFilter.java
@@ -30,44 +30,44 @@ import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControl;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public interface IControlSelectionFilter extends Function<@NotNull IControl, Pair<@NotNull Boolean, @NotNull Boolean>> {
+public interface IControlSelectionFilter extends Function<@Nonnull IControl, Pair<@Nonnull Boolean, @Nonnull Boolean>> {
 
-  @NotNull
-  Pair<@NotNull Boolean, @NotNull Boolean> NON_MATCH = ObjectUtils.notNull(Pair.of(false, false));
-  @NotNull
-  Pair<@NotNull Boolean, @NotNull Boolean> MATCH = ObjectUtils.notNull(Pair.of(true, true));
+  @Nonnull
+  Pair<@Nonnull Boolean, @Nonnull Boolean> NON_MATCH = ObjectUtils.notNull(Pair.of(false, false));
+  @Nonnull
+  Pair<@Nonnull Boolean, @Nonnull Boolean> MATCH = ObjectUtils.notNull(Pair.of(true, true));
 
-  @NotNull
+  @Nonnull
   IControlSelectionFilter ALL_MATCH = new IControlSelectionFilter() {
     @Override
-    public Pair<@NotNull Boolean, @NotNull Boolean> apply(@NotNull IControl control) {
+    public Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
       return MATCH;
     }
   };
 
-  @NotNull
+  @Nonnull
   IControlSelectionFilter NONE_MATCH = new IControlSelectionFilter() {
     @Override
-    public Pair<@NotNull Boolean, @NotNull Boolean> apply(@NotNull IControl control) {
+    public Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
       return NON_MATCH;
     }
   };
 
-  @NotNull
-  static IControlSelectionFilter matchIds(@NotNull String... identifiers) {
+  @Nonnull
+  static IControlSelectionFilter matchIds(@Nonnull String... identifiers) {
     return new IControlSelectionFilter() {
-      private Set<@NotNull String> keys = Arrays.stream(identifiers).collect(Collectors.toUnmodifiableSet());
+      private Set<@Nonnull String> keys = Arrays.stream(identifiers).collect(Collectors.toUnmodifiableSet());
 
       @SuppressWarnings("null")
       @Override
-      public @NotNull Pair<@NotNull Boolean, @NotNull Boolean> apply(@NotNull IControl control) {
+      public @Nonnull Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
         return Pair.of(keys.contains(control.getId()), false);
       }
 
@@ -84,7 +84,7 @@ public interface IControlSelectionFilter extends Function<@NotNull IControl, Pai
    * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
    *         otherwise), and if a match applies to child controls
    */
-  @NotNull
+  @Nonnull
   @Override
-  Pair<@NotNull Boolean, @NotNull Boolean> apply(@NotNull IControl control);
+  Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlSelectionFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IControlSelectionFilter.java
@@ -30,44 +30,44 @@ import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControl;
 
 import org.apache.commons.lang3.tuple.Pair;
-import javax.annotation.Nonnull;
 
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-public interface IControlSelectionFilter extends Function<@Nonnull IControl, Pair<@Nonnull Boolean, @Nonnull Boolean>> {
+import edu.umd.cs.findbugs.annotations.NonNull;
 
-  @Nonnull
-  Pair<@Nonnull Boolean, @Nonnull Boolean> NON_MATCH = ObjectUtils.notNull(Pair.of(false, false));
-  @Nonnull
-  Pair<@Nonnull Boolean, @Nonnull Boolean> MATCH = ObjectUtils.notNull(Pair.of(true, true));
+public interface IControlSelectionFilter extends Function<IControl, Pair<Boolean, Boolean>> {
 
-  @Nonnull
+  @NonNull
+  Pair<Boolean, Boolean> NON_MATCH = ObjectUtils.notNull(Pair.of(false, false));
+  @NonNull
+  Pair<Boolean, Boolean> MATCH = ObjectUtils.notNull(Pair.of(true, true));
+
+  @NonNull
   IControlSelectionFilter ALL_MATCH = new IControlSelectionFilter() {
     @Override
-    public Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
+    public Pair<Boolean, Boolean> apply(IControl control) {
       return MATCH;
     }
   };
 
-  @Nonnull
+  @NonNull
   IControlSelectionFilter NONE_MATCH = new IControlSelectionFilter() {
     @Override
-    public Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
+    public Pair<Boolean, Boolean> apply(IControl control) {
       return NON_MATCH;
     }
   };
 
-  @Nonnull
-  static IControlSelectionFilter matchIds(@Nonnull String... identifiers) {
+  @NonNull
+  static IControlSelectionFilter matchIds(@NonNull String... identifiers) {
     return new IControlSelectionFilter() {
-      private Set<@Nonnull String> keys = Arrays.stream(identifiers).collect(Collectors.toUnmodifiableSet());
+      private Set<String> keys = Arrays.stream(identifiers).collect(Collectors.toUnmodifiableSet());
 
-      @SuppressWarnings("null")
       @Override
-      public @Nonnull Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control) {
+      public @NonNull Pair<Boolean, Boolean> apply(IControl control) {
         return Pair.of(keys.contains(control.getId()), false);
       }
 
@@ -84,7 +84,7 @@ public interface IControlSelectionFilter extends Function<@Nonnull IControl, Pai
    * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
    *         otherwise), and if a match applies to child controls
    */
-  @Nonnull
+  @NonNull
   @Override
-  Pair<@Nonnull Boolean, @Nonnull Boolean> apply(@Nonnull IControl control);
+  Pair<Boolean, Boolean> apply(IControl control);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIdentifierMapper.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIdentifierMapper.java
@@ -28,55 +28,55 @@ package gov.nist.secauto.oscal.lib.profile.resolver;
 
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface IIdentifierMapper {
-  @Nonnull
+  @NonNull
   IIdentifierMapper IDENTITY = new IIdentifierMapper() {
 
     @Override
-    public String mapRoleIdentifier(@Nonnull String identifier) {
+    public String mapRoleIdentifier(@NonNull String identifier) {
       return identifier;
     }
 
     @Override
-    public String mapControlIdentifier(@Nonnull String identifier) {
+    public String mapControlIdentifier(@NonNull String identifier) {
       return identifier;
     }
 
     @Override
-    public String mapGroupIdentifier(@Nonnull String identifier) {
+    public String mapGroupIdentifier(@NonNull String identifier) {
       return identifier;
     }
 
     @Override
-    public String mapParameterIdentifier(@Nonnull String identifier) {
+    public String mapParameterIdentifier(@NonNull String identifier) {
       return identifier;
     }
 
     @Override
-    public @Nonnull String mapPartIdentifier(@Nonnull String identifier) {
+    public @NonNull String mapPartIdentifier(@NonNull String identifier) {
       return identifier;
     }
   };
 
-  @Nonnull
-  String mapRoleIdentifier(@Nonnull String identifier);
+  @NonNull
+  String mapRoleIdentifier(@NonNull String identifier);
 
-  @Nonnull
-  String mapControlIdentifier(@Nonnull String identifier);
+  @NonNull
+  String mapControlIdentifier(@NonNull String identifier);
 
-  @Nonnull
-  String mapGroupIdentifier(@Nonnull String identifier);
+  @NonNull
+  String mapGroupIdentifier(@NonNull String identifier);
 
-  @Nonnull
-  String mapParameterIdentifier(@Nonnull String identifier);
+  @NonNull
+  String mapParameterIdentifier(@NonNull String identifier);
 
-  @Nonnull
-  String mapPartIdentifier(@Nonnull String identifier);
+  @NonNull
+  String mapPartIdentifier(@NonNull String identifier);
 
-  @Nonnull
-  default String mapByItemType(@Nonnull ItemType itemType, @Nonnull String identifier) { // NOPMD - intentional
+  @NonNull
+  default String mapByItemType(@NonNull ItemType itemType, @NonNull String identifier) { // NOPMD - intentional
     String retval;
     switch (itemType) {
     case CONTROL:

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIdentifierMapper.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIdentifierMapper.java
@@ -28,55 +28,55 @@ package gov.nist.secauto.oscal.lib.profile.resolver;
 
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public interface IIdentifierMapper {
-  @NotNull
+  @Nonnull
   IIdentifierMapper IDENTITY = new IIdentifierMapper() {
 
     @Override
-    public String mapRoleIdentifier(@NotNull String identifier) {
+    public String mapRoleIdentifier(@Nonnull String identifier) {
       return identifier;
     }
 
     @Override
-    public String mapControlIdentifier(@NotNull String identifier) {
+    public String mapControlIdentifier(@Nonnull String identifier) {
       return identifier;
     }
 
     @Override
-    public String mapGroupIdentifier(@NotNull String identifier) {
+    public String mapGroupIdentifier(@Nonnull String identifier) {
       return identifier;
     }
 
     @Override
-    public String mapParameterIdentifier(@NotNull String identifier) {
+    public String mapParameterIdentifier(@Nonnull String identifier) {
       return identifier;
     }
 
     @Override
-    public @NotNull String mapPartIdentifier(@NotNull String identifier) {
+    public @Nonnull String mapPartIdentifier(@Nonnull String identifier) {
       return identifier;
     }
   };
 
-  @NotNull
-  String mapRoleIdentifier(@NotNull String identifier);
+  @Nonnull
+  String mapRoleIdentifier(@Nonnull String identifier);
 
-  @NotNull
-  String mapControlIdentifier(@NotNull String identifier);
+  @Nonnull
+  String mapControlIdentifier(@Nonnull String identifier);
 
-  @NotNull
-  String mapGroupIdentifier(@NotNull String identifier);
+  @Nonnull
+  String mapGroupIdentifier(@Nonnull String identifier);
 
-  @NotNull
-  String mapParameterIdentifier(@NotNull String identifier);
+  @Nonnull
+  String mapParameterIdentifier(@Nonnull String identifier);
 
-  @NotNull
-  String mapPartIdentifier(@NotNull String identifier);
+  @Nonnull
+  String mapPartIdentifier(@Nonnull String identifier);
 
-  @NotNull
-  default String mapByItemType(@NotNull ItemType itemType, @NotNull String identifier) { // NOPMD - intentional
+  @Nonnull
+  default String mapByItemType(@Nonnull ItemType itemType, @Nonnull String identifier) { // NOPMD - intentional
     String retval;
     switch (itemType) {
     case CONTROL:

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIndexer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIndexer.java
@@ -28,25 +28,25 @@ package gov.nist.secauto.oscal.lib.profile.resolver;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public interface IIndexer {
-  @NotNull
+  @Nonnull
   Index getIndex();
 
-  EntityItem addRole(@NotNull IRequiredValueModelNodeItem role);
+  EntityItem addRole(@Nonnull IRequiredValueModelNodeItem role);
 
-  EntityItem addLocation(@NotNull IRequiredValueModelNodeItem location);
+  EntityItem addLocation(@Nonnull IRequiredValueModelNodeItem location);
 
-  EntityItem addParty(@NotNull IRequiredValueModelNodeItem party);
+  EntityItem addParty(@Nonnull IRequiredValueModelNodeItem party);
 
-  EntityItem addGroup(@NotNull IRequiredValueModelNodeItem group, boolean selected);
+  EntityItem addGroup(@Nonnull IRequiredValueModelNodeItem group, boolean selected);
 
-  EntityItem addControl(@NotNull IRequiredValueModelNodeItem control, boolean selected);
+  EntityItem addControl(@Nonnull IRequiredValueModelNodeItem control, boolean selected);
 
-  EntityItem addParameter(@NotNull IRequiredValueModelNodeItem parameter);
+  EntityItem addParameter(@Nonnull IRequiredValueModelNodeItem parameter);
 
-  EntityItem addPart(@NotNull IRequiredValueModelNodeItem part);
+  EntityItem addPart(@Nonnull IRequiredValueModelNodeItem part);
 
-  EntityItem addResource(@NotNull IRequiredValueModelNodeItem resource);
+  EntityItem addResource(@Nonnull IRequiredValueModelNodeItem resource);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIndexer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IIndexer.java
@@ -28,25 +28,25 @@ package gov.nist.secauto.oscal.lib.profile.resolver;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface IIndexer {
-  @Nonnull
+  @NonNull
   Index getIndex();
 
-  EntityItem addRole(@Nonnull IRequiredValueModelNodeItem role);
+  EntityItem addRole(@NonNull IRequiredValueModelNodeItem role);
 
-  EntityItem addLocation(@Nonnull IRequiredValueModelNodeItem location);
+  EntityItem addLocation(@NonNull IRequiredValueModelNodeItem location);
 
-  EntityItem addParty(@Nonnull IRequiredValueModelNodeItem party);
+  EntityItem addParty(@NonNull IRequiredValueModelNodeItem party);
 
-  EntityItem addGroup(@Nonnull IRequiredValueModelNodeItem group, boolean selected);
+  EntityItem addGroup(@NonNull IRequiredValueModelNodeItem group, boolean selected);
 
-  EntityItem addControl(@Nonnull IRequiredValueModelNodeItem control, boolean selected);
+  EntityItem addControl(@NonNull IRequiredValueModelNodeItem control, boolean selected);
 
-  EntityItem addParameter(@Nonnull IRequiredValueModelNodeItem parameter);
+  EntityItem addParameter(@NonNull IRequiredValueModelNodeItem parameter);
 
-  EntityItem addPart(@Nonnull IRequiredValueModelNodeItem part);
+  EntityItem addPart(@NonNull IRequiredValueModelNodeItem part);
 
-  EntityItem addResource(@Nonnull IRequiredValueModelNodeItem resource);
+  EntityItem addResource(@NonNull IRequiredValueModelNodeItem resource);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IResult.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IResult.java
@@ -31,36 +31,36 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.Set;
 
 public interface IResult {
 
-  @NotNull
-  Collection<@NotNull Parameter> getPromotedParameters();
+  @Nonnull
+  Collection<@Nonnull Parameter> getPromotedParameters();
 
-  @NotNull
-  Collection<@NotNull Control> getPromotedControls();
+  @Nonnull
+  Collection<@Nonnull Control> getPromotedControls();
 
-  @NotNull
-  Set<@NotNull String> getRequiredParameterIds();
+  @Nonnull
+  Set<@Nonnull String> getRequiredParameterIds();
 
-  boolean isParameterRequired(@NotNull String id);
+  boolean isParameterRequired(@Nonnull String id);
 
-  void promoteParameter(@NotNull Parameter param);
+  void promoteParameter(@Nonnull Parameter param);
 
-  void promoteControl(@NotNull Control control);
+  void promoteControl(@Nonnull Control control);
 
-  void requireParameters(@NotNull Set<@NotNull String> requiredParameterIds);
+  void requireParameters(@Nonnull Set<@Nonnull String> requiredParameterIds);
 
-  void applyTo(@NotNull Catalog parent);
+  void applyTo(@Nonnull Catalog parent);
 
-  void applyTo(@NotNull CatalogGroup parent);
+  void applyTo(@Nonnull CatalogGroup parent);
 
-  void applyTo(@NotNull Control parent);
+  void applyTo(@Nonnull Control parent);
 
-  @NotNull
-  IResult append(@NotNull IResult that);
+  @Nonnull
+  IResult append(@Nonnull IResult that);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IResult.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/IResult.java
@@ -31,36 +31,36 @@ import gov.nist.secauto.oscal.lib.model.CatalogGroup;
 import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.Collection;
 import java.util.Set;
 
 public interface IResult {
 
-  @Nonnull
-  Collection<@Nonnull Parameter> getPromotedParameters();
+  @NonNull
+  Collection<Parameter> getPromotedParameters();
 
-  @Nonnull
-  Collection<@Nonnull Control> getPromotedControls();
+  @NonNull
+  Collection<Control> getPromotedControls();
 
-  @Nonnull
-  Set<@Nonnull String> getRequiredParameterIds();
+  @NonNull
+  Set<String> getRequiredParameterIds();
 
-  boolean isParameterRequired(@Nonnull String id);
+  boolean isParameterRequired(@NonNull String id);
 
-  void promoteParameter(@Nonnull Parameter param);
+  void promoteParameter(@NonNull Parameter param);
 
-  void promoteControl(@Nonnull Control control);
+  void promoteControl(@NonNull Control control);
 
-  void requireParameters(@Nonnull Set<@Nonnull String> requiredParameterIds);
+  void requireParameters(@NonNull Set<String> requiredParameterIds);
 
-  void applyTo(@Nonnull Catalog parent);
+  void applyTo(@NonNull Catalog parent);
 
-  void applyTo(@Nonnull CatalogGroup parent);
+  void applyTo(@NonNull CatalogGroup parent);
 
-  void applyTo(@Nonnull Control parent);
+  void applyTo(@NonNull Control parent);
 
-  @Nonnull
-  IResult append(@Nonnull IResult that);
+  @NonNull
+  IResult append(@NonNull IResult that);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/Import.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/Import.java
@@ -45,7 +45,7 @@ import gov.nist.secauto.oscal.lib.model.ProfileImport;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 import gov.nist.secauto.oscal.lib.profile.resolver.policy.ReferenceCountingVisitor;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.LinkedList;
@@ -54,14 +54,14 @@ import java.util.stream.Collectors;
 
 public class Import {
 
-  @NotNull
+  @Nonnull
   private final IDocumentNodeItem profileDocument;
-  @NotNull
+  @Nonnull
   private final IModelNodeItem profileImportItem;
 
   public Import(
-      @NotNull IDocumentNodeItem profileDocument,
-      @NotNull IModelNodeItem profileImportItem) throws BindingException {
+      @Nonnull IDocumentNodeItem profileDocument,
+      @Nonnull IModelNodeItem profileImportItem) throws BindingException {
 
     this.profileDocument = profileDocument;
     this.profileImportItem = profileImportItem;
@@ -76,26 +76,26 @@ public class Import {
   }
 
   @SuppressWarnings("null")
-  @NotNull
+  @Nonnull
   protected ProfileImport getProfileImport() {
-    return (@NotNull ProfileImport) profileImportItem.getValue();
+    return (@Nonnull ProfileImport) profileImportItem.getValue();
   }
 
   private Catalog toCatalog(IDocumentNodeItem catalogDocument) {
     return (Catalog) catalogDocument.getValue();
   }
 
-  @NotNull
+  @Nonnull
   protected IControlFilter newControlFilter() {
     return IControlFilter.newInstance(getProfileImport());
   }
 
-  @NotNull
+  @Nonnull
   protected IIdentifierMapper newIdentifierMapper() {
     return IIdentifierMapper.IDENTITY;
   }
 
-  public Index resolve(@NotNull IDocumentNodeItem importedCatalogDocument, @NotNull Catalog resolvedCatalog) {
+  public Index resolve(@Nonnull IDocumentNodeItem importedCatalogDocument, @Nonnull Catalog resolvedCatalog) {
     ProfileImport profileImport = getProfileImport();
     URI uri = ObjectUtils.requireNonNull(profileImport.getHref(), "profile import href is null");
 
@@ -135,8 +135,8 @@ public class Import {
     return index;
   }
 
-  private void generateMetadata(@NotNull IDocumentNodeItem importedCatalogDocument, @NotNull Catalog resolvedCatalog,
-      @NotNull Index index) {
+  private void generateMetadata(@Nonnull IDocumentNodeItem importedCatalogDocument, @Nonnull Catalog resolvedCatalog,
+      @Nonnull Index index) {
     Metadata importedMetadata = toCatalog(importedCatalogDocument).getMetadata();
 
     if (importedMetadata != null) {
@@ -183,7 +183,7 @@ public class Import {
     }
   }
 
-  private void generateBackMatter(@NotNull IDocumentNodeItem importedCatalogDocument, @NotNull Catalog resolvedCatalog,
+  private void generateBackMatter(@Nonnull IDocumentNodeItem importedCatalogDocument, @Nonnull Catalog resolvedCatalog,
       Index index) {
     BackMatter importedBackMatter = toCatalog(importedCatalogDocument).getBackMatter();
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ImportCycleException.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ImportCycleException.java
@@ -53,5 +53,4 @@ public class ImportCycleException
   public ImportCycleException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
   }
-
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/Index.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/Index.java
@@ -26,16 +26,15 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver;
 
+import gov.nist.secauto.metaschema.model.common.datatype.adapter.UuidAdapter;
 import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression;
 import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression.ResultType;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.metaschema.model.common.util.CustomCollectors;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.model.control.catalog.ICatalog;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControlContainer;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
-
-import javax.annotation.Nonnull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.EnumMap;
@@ -47,20 +46,23 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 public class Index {
   public static final MetapathExpression HAS_PROP_KEEP = MetapathExpression
       .compile("prop[@name='keep' and has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@value = 'always'");
 
-  @Nonnull
+  @NonNull
   private final Map<ItemType, ItemGroup> entityMap;
-  @Nonnull
+  @NonNull
   private final Set<IControlContainer> selectedContainers;
 
   public static <T, K> Stream<T> merge(
-      @Nonnull Stream<T> resolvedItems,
-      @Nonnull Index index,
-      @Nonnull ItemType itemType,
-      @Nonnull Function<? super T, ? extends K> keyMapper) {
+      @NonNull Stream<T> resolvedItems,
+      @NonNull Index index,
+      @NonNull ItemType itemType,
+      @NonNull Function<? super T, ? extends K> keyMapper) {
     @SuppressWarnings("unchecked")
     Stream<T> importedStream = index.getEntitiesByItemType(itemType).stream()
         .filter(entity -> {
@@ -81,43 +83,44 @@ public class Index {
     this.selectedContainers = new HashSet<>();
   }
 
-  public void markSelected(@Nonnull IControlContainer container) {
+  public void markSelected(@NonNull IControlContainer container) {
     selectedContainers.add(container);
   }
 
-  public boolean isSelected(@Nonnull IControlContainer container) {
+  public boolean isSelected(@NonNull IControlContainer container) {
     return container instanceof ICatalog || selectedContainers.contains(container);
   }
 
   @Nullable
-  protected ItemGroup getItemGroup(@Nonnull ItemType itemType) {
+  protected ItemGroup getItemGroup(@NonNull ItemType itemType) {
     return entityMap.get(itemType);
   }
 
-  protected ItemGroup newItemGroup(@Nonnull ItemType itemType) {
+  protected ItemGroup newItemGroup(@NonNull ItemType itemType) {
     ItemGroup retval = new ItemGroup(itemType);
     entityMap.put(itemType, retval);
     return retval;
   }
 
-  @Nonnull
-  public Collection<@Nonnull EntityItem>
-      getEntitiesByItemType(@Nonnull ItemType itemType) {
+  @NonNull
+  public Collection<EntityItem>
+      getEntitiesByItemType(@NonNull ItemType itemType) {
     ItemGroup group = getItemGroup(itemType);
     return group == null ? CollectionUtil.emptyList() : group.getEntities();
   }
 
-  @SuppressWarnings("null")
-  public EntityItem getEntity(@Nonnull ItemType itemType, @Nonnull UUID identifier) {
+  public EntityItem getEntity(@NonNull ItemType itemType, @NonNull UUID identifier) {
     return getEntity(itemType, identifier.toString());
   }
 
-  public EntityItem getEntity(@Nonnull ItemType itemType, @Nonnull String identifier) {
+  public EntityItem getEntity(@NonNull ItemType itemType, @NonNull String identifier) {
     ItemGroup group = getItemGroup(itemType);
-    return group == null ? null : group.getEntity(identifier);
+
+    String normalizedIdentifier = EntityItem.normalizeIdentifier(itemType, identifier);
+    return group == null ? null : group.getEntity(normalizedIdentifier);
   }
 
-  public <T> EntityItem addItem(@Nonnull EntityItem item) {
+  public <T> EntityItem addItem(@NonNull EntityItem item) {
     ItemType type = item.getItemType();
 
     ItemGroup group = getItemGroup(type);
@@ -136,13 +139,13 @@ public class Index {
   // return count;
   // }
   //
-  // public void incrementParameterReferenceCount(@Nonnull String parameterId) {
+  // public void incrementParameterReferenceCount(@NonNull String parameterId) {
   // int count = getParameterReferenceCount(parameterId);
   //
   // parameterReferenceCountMap.put(parameterId, ++count);
   // }
   //
-  // public void decrementParameterReferenceCount(@Nonnull String parameterId) {
+  // public void decrementParameterReferenceCount(@NonNull String parameterId) {
   // int count = getParameterReferenceCount(parameterId);
   //
   // if (count == 0) {
@@ -159,26 +162,25 @@ public class Index {
   // }
 
   private static class ItemGroup {
-    @Nonnull
+    @NonNull
     private final ItemType itemType;
-    Map<@Nonnull String, EntityItem> idToEntityMap;
+    Map<String, EntityItem> idToEntityMap;
 
-    public ItemGroup(@Nonnull ItemType itemType) {
+    public ItemGroup(@NonNull ItemType itemType) {
       this.itemType = itemType;
       this.idToEntityMap = new LinkedHashMap<>();
     }
 
-    public EntityItem getEntity(@Nonnull String identifier) {
+    public EntityItem getEntity(@NonNull String identifier) {
       return idToEntityMap.get(identifier);
     }
 
-    @SuppressWarnings("null")
-    @Nonnull
-    public Collection<@Nonnull EntityItem> getEntities() {
+    @NonNull
+    public Collection<EntityItem> getEntities() {
       return idToEntityMap.values();
     }
 
-    public EntityItem add(@Nonnull EntityItem entity) {
+    public EntityItem add(@NonNull EntityItem entity) {
       assert itemType.equals(entity.getItemType());
       return idToEntityMap.put(entity.getOriginalIdentifier(), entity);
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/Index.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/Index.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.oscal.lib.model.control.catalog.ICatalog;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControlContainer;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -51,16 +51,16 @@ public class Index {
   public static final MetapathExpression HAS_PROP_KEEP = MetapathExpression
       .compile("prop[@name='keep' and has-oscal-namespace('http://csrc.nist.gov/ns/oscal')]/@value = 'always'");
 
-  @NotNull
+  @Nonnull
   private final Map<ItemType, ItemGroup> entityMap;
-  @NotNull
+  @Nonnull
   private final Set<IControlContainer> selectedContainers;
 
   public static <T, K> Stream<T> merge(
-      @NotNull Stream<T> resolvedItems,
-      @NotNull Index index,
-      @NotNull ItemType itemType,
-      @NotNull Function<? super T, ? extends K> keyMapper) {
+      @Nonnull Stream<T> resolvedItems,
+      @Nonnull Index index,
+      @Nonnull ItemType itemType,
+      @Nonnull Function<? super T, ? extends K> keyMapper) {
     @SuppressWarnings("unchecked")
     Stream<T> importedStream = index.getEntitiesByItemType(itemType).stream()
         .filter(entity -> {
@@ -81,43 +81,43 @@ public class Index {
     this.selectedContainers = new HashSet<>();
   }
 
-  public void markSelected(@NotNull IControlContainer container) {
+  public void markSelected(@Nonnull IControlContainer container) {
     selectedContainers.add(container);
   }
 
-  public boolean isSelected(@NotNull IControlContainer container) {
+  public boolean isSelected(@Nonnull IControlContainer container) {
     return container instanceof ICatalog || selectedContainers.contains(container);
   }
 
   @Nullable
-  protected ItemGroup getItemGroup(@NotNull ItemType itemType) {
+  protected ItemGroup getItemGroup(@Nonnull ItemType itemType) {
     return entityMap.get(itemType);
   }
 
-  protected ItemGroup newItemGroup(@NotNull ItemType itemType) {
+  protected ItemGroup newItemGroup(@Nonnull ItemType itemType) {
     ItemGroup retval = new ItemGroup(itemType);
     entityMap.put(itemType, retval);
     return retval;
   }
 
-  @NotNull
-  public Collection<@NotNull EntityItem>
-      getEntitiesByItemType(@NotNull ItemType itemType) {
+  @Nonnull
+  public Collection<@Nonnull EntityItem>
+      getEntitiesByItemType(@Nonnull ItemType itemType) {
     ItemGroup group = getItemGroup(itemType);
     return group == null ? CollectionUtil.emptyList() : group.getEntities();
   }
 
   @SuppressWarnings("null")
-  public EntityItem getEntity(@NotNull ItemType itemType, @NotNull UUID identifier) {
+  public EntityItem getEntity(@Nonnull ItemType itemType, @Nonnull UUID identifier) {
     return getEntity(itemType, identifier.toString());
   }
 
-  public EntityItem getEntity(@NotNull ItemType itemType, @NotNull String identifier) {
+  public EntityItem getEntity(@Nonnull ItemType itemType, @Nonnull String identifier) {
     ItemGroup group = getItemGroup(itemType);
     return group == null ? null : group.getEntity(identifier);
   }
 
-  public <T> EntityItem addItem(@NotNull EntityItem item) {
+  public <T> EntityItem addItem(@Nonnull EntityItem item) {
     ItemType type = item.getItemType();
 
     ItemGroup group = getItemGroup(type);
@@ -136,13 +136,13 @@ public class Index {
   // return count;
   // }
   //
-  // public void incrementParameterReferenceCount(@NotNull String parameterId) {
+  // public void incrementParameterReferenceCount(@Nonnull String parameterId) {
   // int count = getParameterReferenceCount(parameterId);
   //
   // parameterReferenceCountMap.put(parameterId, ++count);
   // }
   //
-  // public void decrementParameterReferenceCount(@NotNull String parameterId) {
+  // public void decrementParameterReferenceCount(@Nonnull String parameterId) {
   // int count = getParameterReferenceCount(parameterId);
   //
   // if (count == 0) {
@@ -159,26 +159,26 @@ public class Index {
   // }
 
   private static class ItemGroup {
-    @NotNull
+    @Nonnull
     private final ItemType itemType;
-    Map<@NotNull String, EntityItem> idToEntityMap;
+    Map<@Nonnull String, EntityItem> idToEntityMap;
 
-    public ItemGroup(@NotNull ItemType itemType) {
+    public ItemGroup(@Nonnull ItemType itemType) {
       this.itemType = itemType;
       this.idToEntityMap = new LinkedHashMap<>();
     }
 
-    public EntityItem getEntity(@NotNull String identifier) {
+    public EntityItem getEntity(@Nonnull String identifier) {
       return idToEntityMap.get(identifier);
     }
 
     @SuppressWarnings("null")
-    @NotNull
-    public Collection<@NotNull EntityItem> getEntities() {
+    @Nonnull
+    public Collection<@Nonnull EntityItem> getEntities() {
       return idToEntityMap.values();
     }
 
-    public EntityItem add(@NotNull EntityItem entity) {
+    public EntityItem add(@Nonnull EntityItem entity) {
       assert itemType.equals(entity.getItemType());
       return idToEntityMap.put(entity.getOriginalIdentifier(), entity);
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ModifyPhaseUtils.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ModifyPhaseUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.oscal.lib.profile.resolver;
+
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public final class ModifyPhaseUtils {
+  private ModifyPhaseUtils() {
+    // disable construction
+  }
+
+
+  public static <T> Function<? super T, String> identityKey() {
+    return (item) -> Integer.toString(Objects.hashCode(item));
+  }
+
+  public static <T, R> Function<? super T, String> identifierKey(@NonNull Function<T, R> identifierFunction) {
+    return (item) -> {
+      R identifier = identifierFunction.apply(item);
+      String retval;
+      if (identifier == null) {
+        retval = Integer.toString(Objects.hashCode(item));
+      } else {
+        retval = identifier.toString();
+      }
+      return retval;
+    };
+  }
+
+  public static <T> T mergeItem(@Nullable T original, @Nullable T additional) {
+    if (additional == null) {
+      return original; // NOPMD - readability
+    }
+
+    return additional;
+  }
+
+  public static <T> List<T> merge(@Nullable List<T> original, @Nullable List<T> additional,
+      Function<? super T, String> keyFunction) {
+    if (additional == null || additional.isEmpty()) {
+      return original; // NOPMD - readability
+    }
+
+    if (original == null || original.isEmpty()) {
+      return additional; // NOPMD - readability
+    }
+
+    // reverse the stream
+    List<T> reversed = Stream.concat(
+        CollectionUtil.listOrEmpty(original).stream(),
+        CollectionUtil.listOrEmpty(additional).stream())
+        .collect(Collectors.collectingAndThen(
+            Collectors.toList(),
+            l -> {
+              Collections.reverse(l);
+              return l;
+            }));
+
+    // build a map of each unique identity
+    Map<String, List<T>> identityMap = reversed.stream()
+        .collect(Collectors.groupingBy(keyFunction, LinkedHashMap::new, Collectors.toList()));
+
+    // build a reversed list of items, using the first item
+    return identityMap.values().stream()
+        .map(list -> list.stream().findFirst().get())
+        .collect(Collectors.collectingAndThen(
+            Collectors.toList(),
+            l -> {
+              Collections.reverse(l);
+              return l;
+            }));
+  }
+}

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionEvaluationException.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionEvaluationException.java
@@ -24,36 +24,28 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.oscal.lib.profile.resolver.policy;
+package gov.nist.secauto.oscal.lib.profile.resolver;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
-public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
-
-  /**
-   * Get the parser to use to parse an entity identifier from the reference text.
-   * 
-   * @return the parser
-   */
-  @NonNull
-  IIdentifierParser getIdentifierParser();
+public class ProfileResolutionEvaluationException
+    extends IllegalStateException {
 
   /**
-   * Retrieve the reference text from the {@code reference} object.
-   * 
-   * @param reference
-   *          the reference object
-   * @return the reference text or {@code null} if there is no text
+   * the serial version UID.
    */
-  String getReferenceText(@NonNull TYPE reference);
+  private static final long serialVersionUID = 1L;
 
-  /**
-   * Update the reference text used in the {@code reference} object.
-   * 
-   * @param reference
-   *          the reference object
-   * @param newReferenceText
-   *          the reference text replacement
-   */
-  void setReferenceText(@NonNull TYPE reference, @NonNull String newReferenceText);
+  public ProfileResolutionEvaluationException() {
+  }
+
+  public ProfileResolutionEvaluationException(String s) {
+    super(s);
+  }
+
+  public ProfileResolutionEvaluationException(Throwable cause) {
+    super(cause);
+  }
+
+  public ProfileResolutionEvaluationException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionException.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionException.java
@@ -24,36 +24,38 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.oscal.lib.profile.resolver.policy;
+package gov.nist.secauto.oscal.lib.profile.resolver;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
+public class ProfileResolutionException
+    extends Exception {
 
   /**
-   * Get the parser to use to parse an entity identifier from the reference text.
-   * 
-   * @return the parser
+   * the serial version UID.
    */
-  @NonNull
-  IIdentifierParser getIdentifierParser();
+  private static final long serialVersionUID = 1L;
 
   /**
-   * Retrieve the reference text from the {@code reference} object.
+   * Create a new profile resolution exception with the provided {@code message}.
    * 
-   * @param reference
-   *          the reference object
-   * @return the reference text or {@code null} if there is no text
+   * @param message
+   *          a description of the error that occurred
    */
-  String getReferenceText(@NonNull TYPE reference);
+  public ProfileResolutionException(String message) {
+    super(message);
+  }
 
   /**
-   * Update the reference text used in the {@code reference} object.
+   * Create a new profile resolution exception with the provided {@code message} based on the provided
+   * {@code cause}.
    * 
-   * @param reference
-   *          the reference object
-   * @param newReferenceText
-   *          the reference text replacement
+   * @param message
+   *          a description of the error that occurred
+   * @param cause
+   *          the initial cause of the exception
    */
-  void setReferenceText(@NonNull TYPE reference, @NonNull String newReferenceText);
+  public ProfileResolutionException(String message, @NonNull Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/AddVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/AddVisitor.java
@@ -1,0 +1,701 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.oscal.lib.profile.resolver.alter;
+
+import gov.nist.secauto.metaschema.model.common.datatype.markup.MarkupLine;
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
+import gov.nist.secauto.metaschema.model.common.util.CustomCollectors;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.oscal.lib.model.Catalog;
+import gov.nist.secauto.oscal.lib.model.CatalogGroup;
+import gov.nist.secauto.oscal.lib.model.Control;
+import gov.nist.secauto.oscal.lib.model.ControlPart;
+import gov.nist.secauto.oscal.lib.model.Link;
+import gov.nist.secauto.oscal.lib.model.Parameter;
+import gov.nist.secauto.oscal.lib.model.Property;
+import gov.nist.secauto.oscal.lib.model.control.catalog.ICatalogVisitor;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionEvaluationException;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> {
+  public enum TargetType {
+    CONTROL("control", Control.class),
+    PARAM("param", Parameter.class),
+    PART("part", ControlPart.class);
+
+    @NonNull
+    private static final Map<Class<?>, TargetType> CLASS_TO_TYPE;
+    @NonNull
+    private static final Map<String, TargetType> NAME_TO_TYPE;
+    @NonNull
+    private final String fieldName;
+    @NonNull
+    private final Class<?> clazz;
+
+    static {
+      {
+        Map<Class<?>, TargetType> map = new ConcurrentHashMap<>();
+        for (TargetType type : TargetType.values()) {
+          map.put(type.getClazz(), type);
+        }
+        CLASS_TO_TYPE = CollectionUtil.unmodifiableMap(map);
+      }
+
+      {
+        Map<String, TargetType> map = new ConcurrentHashMap<>();
+        for (TargetType type : TargetType.values()) {
+          map.put(type.fieldName(), type);
+        }
+        NAME_TO_TYPE = CollectionUtil.unmodifiableMap(map);
+      }
+    }
+
+    @Nullable
+    public static TargetType forClass(@NonNull Class<?> clazz) {
+      Class<?> target = clazz;
+      TargetType retval;
+      // recurse over parent classes to find a match
+      do {
+        retval = CLASS_TO_TYPE.get(target);
+      } while (retval == null && (target = target.getSuperclass()) != null);
+      return retval;
+    }
+
+    @Nullable
+    public static TargetType forFieldName(@Nullable String name) {
+      return name == null ? null : NAME_TO_TYPE.get(name);
+    }
+
+    TargetType(@NonNull String fieldName, @NonNull Class<?> clazz) {
+      this.fieldName = fieldName;
+      this.clazz = clazz;
+    }
+
+    public String fieldName() {
+      return fieldName;
+    }
+
+    public Class<?> getClazz() {
+      return clazz;
+    }
+  }
+
+  public enum Position {
+    BEFORE,
+    AFTER,
+    STARTING,
+    ENDING;
+
+    @NonNull
+    private static final Map<String, Position> NAME_TO_POSITION;
+
+    static {
+      Map<String, Position> map = new ConcurrentHashMap<>();
+      for (Position position : Position.values()) {
+        map.put(position.name().toLowerCase(Locale.ROOT), position);
+      }
+      NAME_TO_POSITION = CollectionUtil.unmodifiableMap(map);
+    }
+
+    @Nullable
+    public static Position forName(@Nullable String name) {
+      return name == null ? null : NAME_TO_POSITION.get(name);
+    }
+  }
+
+  @NonNull
+  private static final AddVisitor INSTANCE = new AddVisitor();
+  private static final Map<TargetType, Set<TargetType>> APPLICABLE_TARGETS;
+
+  static {
+    APPLICABLE_TARGETS = new EnumMap<>(TargetType.class);
+    APPLICABLE_TARGETS.put(TargetType.CONTROL, Set.of(TargetType.CONTROL, TargetType.PARAM, TargetType.PART));
+    APPLICABLE_TARGETS.put(TargetType.PARAM, Set.of(TargetType.PARAM));
+    APPLICABLE_TARGETS.put(TargetType.PART, Set.of(TargetType.PART));
+  }
+
+  private static Set<TargetType> getApplicableTypes(@NonNull TargetType type) {
+    return APPLICABLE_TARGETS.getOrDefault(type, CollectionUtil.emptySet());
+  }
+
+  /**
+   * Apply the add directive.
+   * 
+   * @param control
+   *          the control target
+   * @param position
+   *          the position to apply the content or {@code null}
+   * @param byId
+   *          the identifier of the target or {@code null}
+   * @param title
+   *          a title to set
+   * @param params
+   *          parameters to add
+   * @param props
+   *          properties to add
+   * @param links
+   *          links to add
+   * @param parts
+   *          parts to add
+   * @return {@code true} if the modification was made or {@code false} otherwise
+   * @throws ProfileResolutionEvaluationException
+   *           if a processing error occurred during profile resolution
+   */
+  public static boolean add(
+      @NonNull Control control,
+      @Nullable Position position,
+      @Nullable String byId,
+      @Nullable MarkupLine title,
+      @NonNull List<Parameter> params,
+      @NonNull List<Property> props,
+      @NonNull List<Link> links,
+      @NonNull List<ControlPart> parts) {
+    return INSTANCE.visitControl(
+        control,
+        new Context(
+            control,
+            position == null ? Position.ENDING : position,
+            byId,
+            title,
+            params,
+            props,
+            links,
+            parts));
+  }
+
+  @Override
+  public Boolean visitCatalog(Catalog catalog, Context context) {
+    // not required
+    throw new UnsupportedOperationException("not needed");
+  }
+
+  @Override
+  public Boolean visitGroup(CatalogGroup group, Context context) {
+    // not required
+    throw new UnsupportedOperationException("not needed");
+  }
+
+  /**
+   * If the add applies to the current object, then apply the child objects.
+   * <p>
+   * An add applies if:
+   * <ol>
+   * <li>the {@code targetItem} supports all of the children</li>
+   * <li>the context matches if:
+   * <ul>
+   * <li>the target item's id matches the "by-id"; or</li>
+   * <li>the "by-id" is not defined and the target item is the control matching the target
+   * context</li>
+   * </ul>
+   * </li>
+   * </ol>
+   * 
+   * @param <T>
+   *          the type of the {@code targetItem}
+   * @param targetItem
+   *          the current target to process
+   * @param titleConsumer
+   *          a consumer to apply a title to or {@code null} if the object has no title field
+   * @param paramsSupplier
+   *          a supplier for the child {@link Parameter} collection
+   * @param propsSupplier
+   *          a supplier for the child {@link Property} collection
+   * @param linksSupplier
+   *          a supplier for the child {@link Link} collection
+   * @param partsSupplier
+   *          a supplier for the child {@link ControlPart} collection
+   * @param context
+   *          the add context
+   * @return {@code true} if a modification was made or {@code false} otherwise
+   */
+  private static <T> boolean handleCurrent(
+      @NonNull T targetItem,
+      @Nullable Consumer<MarkupLine> titleConsumer,
+      @Nullable Supplier<? extends List<Parameter>> paramsSupplier,
+      @Nullable Supplier<? extends List<Property>> propsSupplier,
+      @Nullable Supplier<? extends List<Link>> linksSupplier,
+      @Nullable Supplier<? extends List<ControlPart>> partsSupplier,
+      @NonNull Context context) {
+    boolean retval = false;
+    Position position = context.getPosition();
+    if (context.appliesTo(targetItem) && !context.isSequenceTargeted(targetItem)) {
+      // the target item is the target of the add
+      MarkupLine newTitle = context.getTitle();
+      if (newTitle != null) {
+        assert titleConsumer != null;
+        titleConsumer.accept(newTitle);
+      }
+
+      handleCollection(position, context.getParams(), paramsSupplier);
+      handleCollection(position, context.getProps(), propsSupplier);
+      handleCollection(position, context.getLinks(), linksSupplier);
+      handleCollection(position, context.getParts(), partsSupplier);
+      retval = true;
+    }
+    return retval;
+  }
+
+  private static <T> void handleCollection(
+      @NonNull Position position,
+      @NonNull List<T> newItems,
+      @Nullable Supplier<? extends List<T>> originalCollectionSupplier) {
+    if (originalCollectionSupplier != null) {
+      List<T> oldItems = originalCollectionSupplier.get();
+      if (!newItems.isEmpty()) {
+        if (Position.STARTING.equals(position)) {
+          oldItems.addAll(0, newItems);
+        } else { // ENDING
+          oldItems.addAll(newItems);
+        }
+      }
+    }
+  }
+
+  // private static <T> void handleChild(
+  // @NonNull TargetType itemType,
+  // @NonNull Supplier<? extends List<T>> collectionSupplier,
+  // @Nullable Consumer<T> handler,
+  // @NonNull Context context) {
+  // boolean handleChildren = !Collections.disjoint(context.getTargetItemTypes(),
+  // getApplicableTypes(itemType));
+  // if (handleChildren && handler != null) {
+  // // if the child item type is applicable and there is a handler, iterate over children
+  // Iterator<T> iter = collectionSupplier.get().iterator();
+  // while (iter.hasNext()) {
+  // T item = iter.next();
+  // if (item != null) {
+  // handler.accept(item);
+  // }
+  // }
+  // }
+  // }
+
+  private static <T> boolean handleChild(
+      @NonNull TargetType itemType,
+      @NonNull Supplier<? extends List<T>> originalCollectionSupplier,
+      @NonNull Supplier<? extends List<T>> newItemsSupplier,
+      @Nullable Function<T, Boolean> handler,
+      @NonNull Context context) {
+
+    // determine if this child type can match
+    boolean isItemTypeMatch = context.isMatchingType(itemType);
+
+    Set<TargetType> applicableTypes = getApplicableTypes(itemType);
+    boolean descendChild = handler != null && !Collections.disjoint(context.getTargetItemTypes(), applicableTypes);
+
+    boolean retval = false;
+    if (isItemTypeMatch || descendChild) {
+      // if the item type is applicable, attempt to match by id
+      List<T> collection = originalCollectionSupplier.get();
+      ListIterator<T> iter = collection.listIterator();
+      boolean deferred = false;
+      while (iter.hasNext()) {
+        T item = ObjectUtils.requireNonNull(iter.next());
+
+        if (isItemTypeMatch && context.appliesTo(item) && context.isSequenceTargeted(item)) {
+          // if id match, inject the new items into the collection
+          switch (context.getPosition()) {
+          case AFTER: {
+            newItemsSupplier.get().forEach(add -> iter.add(add));
+            retval = true;
+            break;
+          }
+          case BEFORE: {
+            iter.previous();
+            List<T> adds = newItemsSupplier.get();
+            adds.forEach(add -> iter.add(add));
+            item = iter.next();
+            retval = true;
+            break;
+          }
+          case STARTING:
+          case ENDING:
+            deferred = true;
+            break;
+          default:
+            throw new UnsupportedOperationException(context.getPosition().name().toLowerCase(Locale.ROOT));
+          }
+        }
+
+        if (descendChild) {
+          assert handler != null;
+
+          // handle child items since they are applicable to the search criteria
+          retval = retval || handler.apply(item);
+        }
+      }
+
+      if (deferred) {
+        List<T> newItems = newItemsSupplier.get();
+        if (Position.ENDING.equals(context.getPosition())) {
+          collection.addAll(newItems);
+          retval = true;
+        } else if (Position.STARTING.equals(context.getPosition())) {
+          collection.addAll(0, newItems);
+          retval = true;
+        }
+      }
+    }
+    return retval;
+  }
+
+  @Override
+  public Boolean visitControl(Control control, Context context) {
+    assert context != null;
+
+    if (control.getParams() == null) {
+      control.setParams(new LinkedList<>());
+    }
+
+    if (control.getProps() == null) {
+      control.setProps(new LinkedList<>());
+    }
+
+    if (control.getLinks() == null) {
+      control.setLinks(new LinkedList<>());
+    }
+
+    if (control.getParts() == null) {
+      control.setParts(new LinkedList<>());
+    }
+
+    boolean retval = handleCurrent(
+        control,
+        title -> control.setTitle(title),
+        () -> control.getParams(),
+        () -> control.getProps(),
+        () -> control.getLinks(),
+        () -> control.getParts(),
+        context);
+
+    // visit params
+    retval = retval || handleChild(
+        TargetType.PARAM,
+        () -> control.getParams(),
+        () -> context.getParams(),
+        child -> visitParameter(ObjectUtils.notNull(child), context),
+        context);
+
+    // visit parts
+    retval = retval || handleChild(
+        TargetType.PART,
+        () -> control.getParts(),
+        () -> context.getParts(),
+        child -> visitPart(child, context),
+        context);
+    return retval;
+  }
+
+  @Override
+  public Boolean visitParameter(Parameter parameter, Context context) {
+    assert context != null;
+    if (parameter.getProps() == null) {
+      parameter.setProps(new LinkedList<>());
+    }
+
+    if (parameter.getLinks() == null) {
+      parameter.setLinks(new LinkedList<>());
+    }
+
+    return handleCurrent(
+        parameter,
+        null,
+        null,
+        () -> parameter.getProps(),
+        () -> parameter.getLinks(),
+        null,
+        context);
+  }
+
+  public Boolean visitPart(ControlPart part, Context context) {
+    assert context != null;
+    if (part.getProps() == null) {
+      part.setProps(new LinkedList<>());
+    }
+
+    if (part.getLinks() == null) {
+      part.setLinks(new LinkedList<>());
+    }
+
+    if (part.getParts() == null) {
+      part.setParts(new LinkedList<>());
+    }
+
+    boolean retval = handleCurrent(
+        part,
+        null,
+        null,
+        () -> part.getProps(),
+        () -> part.getLinks(),
+        () -> part.getParts(),
+        context);
+
+    // visit parts
+    retval = retval || handleChild(
+        TargetType.PART,
+        () -> part.getParts(),
+        () -> context.getParts(),
+        child -> visitPart(child, context),
+        context);
+    return retval;
+  }
+
+  static class Context {
+    @NonNull
+    private static final Set<TargetType> TITLE_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.CONTROL, TargetType.PART));
+    @NonNull
+    private static final Set<TargetType> PARAM_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.CONTROL, TargetType.PARAM));
+    @NonNull
+    private static final Set<TargetType> PROP_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.CONTROL, TargetType.PARAM, TargetType.PART));
+    @NonNull
+    private static final Set<TargetType> LINK_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.CONTROL, TargetType.PARAM, TargetType.PART));
+    @NonNull
+    private static final Set<TargetType> PART_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.CONTROL, TargetType.PART));
+
+    @NonNull
+    private final Control control;
+    @NonNull
+    private final Position position;
+    @Nullable
+    private final String byId;
+    @Nullable
+    private final MarkupLine title;
+    @NonNull
+    private final List<Parameter> params;
+    @NonNull
+    private final List<Property> props;
+    @NonNull
+    private final List<Link> links;
+    @NonNull
+    private final List<ControlPart> parts;
+    @NonNull
+    private final Set<TargetType> targetItemTypes;
+
+    public Context(
+        @NonNull Control control,
+        @NonNull Position position,
+        @Nullable String byId,
+        @Nullable MarkupLine title,
+        @NonNull List<Parameter> params,
+        @NonNull List<Property> props,
+        @NonNull List<Link> links,
+        @NonNull List<ControlPart> parts) {
+
+      Set<TargetType> targetItemTypes = ObjectUtils.notNull(EnumSet.allOf(TargetType.class));
+
+      List<String> additionObjects = new LinkedList<>();
+
+      boolean sequenceTarget = true;
+      if (title != null) {
+        targetItemTypes.retainAll(TITLE_TYPES);
+        additionObjects.add("title");
+        sequenceTarget = false;
+      }
+
+      if (!params.isEmpty()) {
+        targetItemTypes.retainAll(PARAM_TYPES);
+        additionObjects.add("param");
+      }
+
+      if (!props.isEmpty()) {
+        targetItemTypes.retainAll(PROP_TYPES);
+        additionObjects.add("prop");
+        sequenceTarget = false;
+      }
+
+      if (!links.isEmpty()) {
+        targetItemTypes.retainAll(LINK_TYPES);
+        additionObjects.add("link");
+        sequenceTarget = false;
+      }
+
+      if (!parts.isEmpty()) {
+        targetItemTypes.retainAll(PART_TYPES);
+        additionObjects.add("part");
+      }
+
+      if (Position.BEFORE.equals(position) || Position.AFTER.equals(position)) {
+        if (sequenceTarget) {
+          if (sequenceTarget && !params.isEmpty() && parts.isEmpty()) {
+            targetItemTypes.retainAll(Set.of(TargetType.PARAM));
+          } else if (sequenceTarget && !parts.isEmpty() && params.isEmpty()) {
+            targetItemTypes.retainAll(Set.of(TargetType.PART));
+          } else {
+            throw new ProfileResolutionEvaluationException(
+                "When using position before or after, only one collection of parameters or parts can be specified.");
+          }
+        } else {
+          throw new ProfileResolutionEvaluationException(
+              "When using position before or after, one collection of parameters or parts can be specified."
+                  + " Other additions must not be used.");
+        }
+      }
+
+      if (targetItemTypes.isEmpty()) {
+        throw new ProfileResolutionEvaluationException("No parent object supports the requested objects to add: " +
+            additionObjects.stream().collect(CustomCollectors.joiningWithOxfordComma("or")));
+      }
+
+      this.control = control;
+      this.position = position;
+      this.byId = byId;
+      this.title = title;
+      this.params = params;
+      this.props = props;
+      this.links = links;
+      this.parts = parts;
+      this.targetItemTypes = CollectionUtil.unmodifiableSet(targetItemTypes);
+    }
+
+    public Control getControl() {
+      return control;
+    }
+
+    @NonNull
+    public Position getPosition() {
+      return position;
+    }
+
+    @Nullable
+    public String getById() {
+      return byId;
+    }
+
+    @Nullable
+    public MarkupLine getTitle() {
+      return title;
+    }
+
+    @NonNull
+    public List<Parameter> getParams() {
+      return params;
+    }
+
+    @NonNull
+    public List<Property> getProps() {
+      return props;
+    }
+
+    @NonNull
+    public List<Link> getLinks() {
+      return links;
+    }
+
+    @NonNull
+    public List<ControlPart> getParts() {
+      return parts;
+    }
+
+    @NonNull
+    public Set<TargetType> getTargetItemTypes() {
+      return targetItemTypes;
+    }
+
+    public boolean isMatchingType(@NonNull TargetType type) {
+      return getTargetItemTypes().contains(type);
+    }
+
+    public <T> boolean isSequenceTargeted(T targetItem) {
+      TargetType objectType = TargetType.forClass(targetItem.getClass());
+      return (Position.BEFORE.equals(position) || Position.AFTER.equals(position))
+          && (TargetType.PARAM.equals(objectType) && isMatchingType(TargetType.PARAM)
+              || TargetType.PART.equals(objectType) && isMatchingType(TargetType.PART));
+    }
+
+    protected boolean checkValue(@Nullable String actual, @Nullable String expected) {
+      return expected == null || expected.equals(actual);
+    }
+
+    /**
+     * Determine if the provided {@code obj} is the target of the add.
+     * 
+     * @param obj
+     *          the current object
+     * @return {@code true} if the current object applies or {@code false} otherwise
+     */
+    public boolean appliesTo(@NonNull Object obj) {
+      TargetType objectType = TargetType.forClass(obj.getClass());
+
+      boolean retval = objectType != null && isMatchingType(objectType);
+      if (retval) {
+        assert objectType != null;
+
+        // check other criteria
+        String actualId = null;
+
+        switch (objectType) {
+        case CONTROL: {
+          Control control = (Control) obj;
+          actualId = control.getId();
+          break;
+        }
+        case PARAM: {
+          Parameter param = (Parameter) obj;
+          actualId = param.getId();
+          break;
+        }
+        case PART: {
+          ControlPart part = (ControlPart) obj;
+          actualId = part.getId() == null ? null : part.getId().toString();
+          break;
+        }
+        default:
+          throw new UnsupportedOperationException(objectType.fieldName());
+        }
+
+        String byId = getById();
+        if (getById() == null && TargetType.CONTROL.equals(objectType)) {
+          retval = getControl().equals(obj);
+        } else {
+          retval = byId != null && byId.equals(actualId);
+        }
+      }
+      return retval;
+    }
+  }
+}

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/RemoveVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/RemoveVisitor.java
@@ -1,0 +1,516 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.oscal.lib.profile.resolver.alter;
+
+import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
+import gov.nist.secauto.oscal.lib.model.Catalog;
+import gov.nist.secauto.oscal.lib.model.CatalogGroup;
+import gov.nist.secauto.oscal.lib.model.Control;
+import gov.nist.secauto.oscal.lib.model.ControlPart;
+import gov.nist.secauto.oscal.lib.model.Link;
+import gov.nist.secauto.oscal.lib.model.MappingEntry;
+import gov.nist.secauto.oscal.lib.model.Parameter;
+import gov.nist.secauto.oscal.lib.model.Property;
+import gov.nist.secauto.oscal.lib.model.control.catalog.ICatalogVisitor;
+import gov.nist.secauto.oscal.lib.model.metadata.IProperty;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionEvaluationException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Context> {
+  public enum TargetType {
+    PARAM("param", Parameter.class),
+    PROP("prop", Property.class),
+    LINK("link", Link.class),
+    PART("part", ControlPart.class),
+    MAPPING("mapping", Control.Mapping.class),
+    MAP("map", MappingEntry.class);
+
+    @NonNull
+    private static final Map<Class<?>, TargetType> CLASS_TO_TYPE;
+    @NonNull
+    private static final Map<String, TargetType> NAME_TO_TYPE;
+    @NonNull
+    private final String fieldName;
+    @NonNull
+    private final Class<?> clazz;
+
+    static {
+      {
+        Map<Class<?>, TargetType> map = new ConcurrentHashMap<>();
+        for (TargetType type : TargetType.values()) {
+          map.put(type.getClazz(), type);
+        }
+        CLASS_TO_TYPE = CollectionUtil.unmodifiableMap(map);
+      }
+
+      {
+        Map<String, TargetType> map = new ConcurrentHashMap<>();
+        for (TargetType type : TargetType.values()) {
+          map.put(type.fieldName(), type);
+        }
+        NAME_TO_TYPE = CollectionUtil.unmodifiableMap(map);
+      }
+    }
+
+    @Nullable
+    public static TargetType forClass(@NonNull Class<?> clazz) {
+      Class<?> target = clazz;
+      TargetType retval;
+      // recurse over parent classes to find a match
+      do {
+        retval = CLASS_TO_TYPE.get(target);
+      } while (retval == null && (target = target.getSuperclass()) != null);
+      return retval;
+    }
+
+    @Nullable
+    public static TargetType forFieldName(@Nullable String name) {
+      return name == null ? null : NAME_TO_TYPE.get(name);
+    }
+
+    TargetType(@NonNull String fieldName, @NonNull Class<?> clazz) {
+      this.fieldName = fieldName;
+      this.clazz = clazz;
+    }
+
+    public String fieldName() {
+      return fieldName;
+    }
+
+    public Class<?> getClazz() {
+      return clazz;
+    }
+
+  }
+
+  @NonNull
+  private static final RemoveVisitor INSTANCE = new RemoveVisitor();
+
+  private static final Map<TargetType, Set<TargetType>> APPLICABLE_TARGETS;
+
+  static {
+    APPLICABLE_TARGETS = new EnumMap<>(TargetType.class);
+    APPLICABLE_TARGETS.put(TargetType.PARAM, Set.of(TargetType.PROP, TargetType.LINK));
+    APPLICABLE_TARGETS.put(TargetType.PART, Set.of(TargetType.PART, TargetType.PROP, TargetType.LINK));
+    APPLICABLE_TARGETS.put(TargetType.MAPPING, Set.of(TargetType.MAP, TargetType.PROP, TargetType.LINK));
+    APPLICABLE_TARGETS.put(TargetType.MAP, Set.of(TargetType.PROP, TargetType.LINK));
+  }
+
+  private static Set<TargetType> getApplicableTypes(@NonNull TargetType type) {
+    return APPLICABLE_TARGETS.getOrDefault(type, CollectionUtil.emptySet());
+  }
+
+  private static <T> boolean handle(
+      @NonNull TargetType itemType,
+      @NonNull Supplier<? extends Collection<T>> supplier,
+      @Nullable Function<T, Boolean> handler,
+      @NonNull Context context) {
+
+    boolean handleChildren = !Collections.disjoint(context.getTargetItemTypes(), getApplicableTypes(itemType));
+    boolean retval = false;
+    if (context.isMatchingType(itemType)) {
+      // if the item type is applicable, attempt to remove any items
+      Iterator<T> iter = supplier.get().iterator();
+      while (iter.hasNext()) {
+        T item = iter.next();
+
+        if (item == null || context.appliesTo(item)) {
+          iter.remove();
+          retval = true;
+          // ignore removed items and their children
+        } else if (handler != null && handleChildren) {
+          // handle child items since they are applicable to the search criteria
+          retval = retval || handler.apply(item);
+        }
+      }
+    } else if (handleChildren && handler != null) {
+      // if the child item type is applicable and there is a handler, iterate over children
+      Iterator<T> iter = supplier.get().iterator();
+      while (iter.hasNext()) {
+        T item = iter.next();
+        if (item != null) {
+          retval = retval || handler.apply(item);
+        }
+      }
+    }
+    return retval;
+  }
+
+  /**
+   * Apply the remove directive.
+   * 
+   * @param control
+   *          the control target
+   * @param objectName
+   *          the name flag of a matching node to remove
+   * @param objectClass
+   *          the class flag of a matching node to remove
+   * @param objectId
+   *          the id flag of a matching node to remove
+   * @param objectNamespace
+   *          the namespace flag of a matching node to remove
+   * @param itemType
+   *          the type of a matching node to remove
+   * @return {@code true} if the modification was made or {@code false} otherwise
+   * @throws ProfileResolutionEvaluationException
+   *           if a processing error occurred during profile resolution
+   */
+  public static boolean remove(
+      @NonNull Control control,
+      @Nullable String objectName,
+      @Nullable String objectClass,
+      @Nullable String objectId,
+      @Nullable String objectNamespace,
+      @Nullable TargetType itemType) {
+    return INSTANCE.visitControl(
+        control,
+        new Context(objectName, objectClass, objectId, objectNamespace, itemType));
+  }
+
+  @Override
+  public Boolean visitCatalog(Catalog catalog, Context context) {
+    // not required
+    throw new UnsupportedOperationException("not needed");
+  }
+
+  @Override
+  public Boolean visitGroup(CatalogGroup group, Context context) {
+    // not required
+    throw new UnsupportedOperationException("not needed");
+  }
+
+  @Override
+  public Boolean visitControl(Control control, Context context) {
+    assert context != null;
+
+    // visit params
+    boolean retval = handle(
+        TargetType.PARAM,
+        () -> CollectionUtil.listOrEmpty(control.getParams()),
+        child -> visitParameter(ObjectUtils.notNull(child), context),
+        context);
+
+    // visit props
+    retval = retval || handle(
+        TargetType.PROP,
+        () -> CollectionUtil.listOrEmpty(control.getProps()),
+        null,
+        context);
+
+    // visit links
+    retval = retval || handle(
+        TargetType.LINK,
+        () -> CollectionUtil.listOrEmpty(control.getLinks()),
+        null,
+        context);
+
+    // visit parts
+    retval = retval || handle(
+        TargetType.PART,
+        () -> CollectionUtil.listOrEmpty(control.getParts()),
+        child -> visitPart(child, context),
+        context);
+
+    // visit mappings
+    Control.Mapping mapping = control.getMapping();
+    if (mapping != null) {
+      retval = retval || visitMapping(mapping, context);
+    }
+    return retval;
+  }
+
+  @Override
+  public Boolean visitParameter(Parameter parameter, Context context) {
+    assert context != null;
+
+    // visit props
+    boolean retval = handle(
+        TargetType.PROP,
+        () -> CollectionUtil.listOrEmpty(parameter.getProps()),
+        null,
+        context);
+
+    // visit links
+    retval = retval || handle(
+        TargetType.LINK,
+        () -> CollectionUtil.listOrEmpty(parameter.getLinks()),
+        null,
+        context);
+    return retval;
+  }
+
+  public Boolean visitPart(ControlPart part, Context context) {
+    assert context != null;
+
+    // visit props
+    boolean retval = handle(
+        TargetType.PROP,
+        () -> CollectionUtil.listOrEmpty(part.getProps()),
+        null,
+        context);
+
+    // visit links
+    retval = retval || handle(
+        TargetType.LINK,
+        () -> CollectionUtil.listOrEmpty(part.getLinks()),
+        null,
+        context);
+
+    // visit parts
+    retval = retval || handle(
+        TargetType.PART,
+        () -> CollectionUtil.listOrEmpty(part.getParts()),
+        child -> visitPart(child, context),
+        context);
+    return retval;
+  }
+
+  public Boolean visitMapping(Control.Mapping mapping, Context context) {
+    assert context != null;
+
+    // visit maps
+    return handle(
+        TargetType.MAP,
+        () -> CollectionUtil.listOrEmpty(mapping.getMaps()),
+        child -> visitMap(child, context),
+        context);
+  }
+
+  public Boolean visitMap(MappingEntry map, Context context) {
+    assert context != null;
+
+    // visit props
+    boolean retval = handle(
+        TargetType.PROP,
+        () -> CollectionUtil.listOrEmpty(map.getProps()),
+        null,
+        context);
+
+    // visit links
+    retval = retval || handle(
+        TargetType.LINK,
+        () -> CollectionUtil.listOrEmpty(map.getLinks()),
+        null,
+        context);
+    return retval;
+  }
+
+  static class Context {
+    /**
+     * Types with an "name" flag.
+     */
+    @NonNull
+    private static final Set<TargetType> NAME_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.PART, TargetType.PROP));
+    /**
+     * Types with an "class" flag.
+     */
+    @NonNull
+    private static final Set<TargetType> CLASS_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.PARAM, TargetType.PART, TargetType.PROP));
+    /**
+     * Types with an "id" flag.
+     */
+    @NonNull
+    private static final Set<TargetType> ID_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.PARAM, TargetType.PART));
+    /**
+     * Types with an "ns" flag.
+     */
+    @NonNull
+    private static final Set<TargetType> NAMESPACE_TYPES = ObjectUtils.notNull(
+        Set.of(TargetType.PART, TargetType.PROP));
+
+    @Nullable
+    private final String objectName;
+    @Nullable
+    private final String objectClass;
+    @Nullable
+    private final String objectId;
+    @Nullable
+    private final String objectNamespace;
+    @NonNull
+    private final Set<TargetType> targetItemTypes;
+
+    private static boolean filterTypes(
+        @NonNull Set<TargetType> effectiveTypes,
+        @NonNull String criteria,
+        @NonNull Set<TargetType> allowedTypes,
+        @Nullable String value,
+        @Nullable TargetType itemType) {
+      boolean retval = false;
+      if (value != null) {
+        retval = effectiveTypes.retainAll(allowedTypes);
+        if (itemType != null && !allowedTypes.contains(itemType)) {
+          throw new ProfileResolutionEvaluationException(
+              String.format("%s='%s' is not supported for items of type '%s'",
+                  criteria,
+                  value,
+                  itemType.fieldName()));
+        }
+      }
+      return retval;
+    }
+
+    private Context(
+        @Nullable String objectName,
+        @Nullable String objectClass,
+        @Nullable String objectId,
+        @Nullable String objectNamespace,
+        @Nullable TargetType itemType) {
+
+      // determine the set of effective item types to search for
+      // this helps with short-circuit searching for parts of the graph that cannot match
+      @NonNull
+      Set<TargetType> targetItemTypes = ObjectUtils.notNull(EnumSet.allOf(TargetType.class));
+      filterTypes(targetItemTypes, "by-name", NAME_TYPES, objectName, itemType);
+      filterTypes(targetItemTypes, "by-class", CLASS_TYPES, objectClass, itemType);
+      filterTypes(targetItemTypes, "by-id", ID_TYPES, objectId, itemType);
+      filterTypes(targetItemTypes, "by-ns", NAMESPACE_TYPES, objectNamespace, itemType);
+
+      if (itemType != null) {
+        targetItemTypes.retainAll(Set.of(itemType));
+      }
+
+      if (targetItemTypes.isEmpty()) {
+        throw new ProfileResolutionEvaluationException("The filter matches no available item types");
+      }
+
+      this.objectName = objectName;
+      this.objectClass = objectClass;
+      this.objectId = objectId;
+      this.objectNamespace = objectNamespace;
+      this.targetItemTypes = CollectionUtil.unmodifiableSet(targetItemTypes);
+    }
+
+    @Nullable
+    public String getObjectName() {
+      return objectName;
+    }
+
+    @Nullable
+    public String getObjectClass() {
+      return objectClass;
+    }
+
+    @Nullable
+    public String getObjectId() {
+      return objectId;
+    }
+
+    @NonNull
+    public Set<TargetType> getTargetItemTypes() {
+      return targetItemTypes;
+    }
+
+    public boolean isMatchingType(@NonNull TargetType type) {
+      return getTargetItemTypes().contains(type);
+    }
+
+    @Nullable
+    public String getObjectNamespace() {
+      return objectNamespace;
+    }
+
+    protected boolean checkValue(@Nullable String actual, @Nullable String expected) {
+      return expected != null && expected.equals(actual);
+    }
+
+    public boolean appliesTo(@NonNull Object obj) {
+      TargetType objectType = TargetType.forClass(obj.getClass());
+
+      boolean retval = objectType != null && getTargetItemTypes().contains(objectType);
+      if (retval) {
+        assert objectType != null;
+
+        // check other criteria
+        String actualName = null;
+        String actualClass = null;
+        String actualId = null;
+        String actualNamespace = null;
+
+        switch (objectType) {
+        case PARAM: {
+          Parameter param = (Parameter) obj;
+          actualClass = param.getClazz();
+          actualId = param.getId();
+          break;
+        }
+        case PROP: {
+          Property prop = (Property) obj;
+          actualName = prop.getName();
+          actualClass = prop.getClazz();
+          actualNamespace = prop.getNs() == null ? IProperty.OSCAL_NAMESPACE.toString() : prop.getNs().toString();
+          break;
+        }
+        case PART: {
+          ControlPart part = (ControlPart) obj;
+          actualName = part.getName();
+          actualClass = part.getClazz();
+          actualId = part.getId() == null ? null : part.getId().toString();
+          actualNamespace = part.getNs() == null ? IProperty.OSCAL_NAMESPACE.toString() : part.getNs().toString();
+          break;
+        }
+        case LINK:
+        case MAPPING:
+        case MAP:
+          // do nothing
+          break;
+        default:
+          throw new UnsupportedOperationException(objectType.name().toLowerCase(Locale.ROOT));
+        }
+
+        retval = checkValue(actualName, getObjectName());
+        if (retval) {
+          checkValue(actualClass, getObjectClass());
+        }
+        if (retval) {
+          checkValue(actualId, getObjectId());
+        }
+        if (retval) {
+          checkValue(actualNamespace, getObjectNamespace());
+        }
+      }
+      return retval;
+    }
+  }
+}

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/package-info.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/package-info.java
@@ -24,36 +24,4 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.oscal.lib.profile.resolver.policy;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
-
-public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
-
-  /**
-   * Get the parser to use to parse an entity identifier from the reference text.
-   * 
-   * @return the parser
-   */
-  @NonNull
-  IIdentifierParser getIdentifierParser();
-
-  /**
-   * Retrieve the reference text from the {@code reference} object.
-   * 
-   * @param reference
-   *          the reference object
-   * @return the reference text or {@code null} if there is no text
-   */
-  String getReferenceText(@NonNull TYPE reference);
-
-  /**
-   * Update the reference text used in the {@code reference} object.
-   * 
-   * @param reference
-   *          the reference object
-   * @param newReferenceText
-   *          the reference text replacement
-   */
-  void setReferenceText(@NonNull TYPE reference, @NonNull String newReferenceText);
-}
+package gov.nist.secauto.oscal.lib.profile.resolver.alter;

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractCustomReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractCustomReferencePolicy.java
@@ -32,24 +32,25 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomReferencePolicy<TYPE> {
   private static final Logger LOGGER = LogManager.getLogger(AbstractCustomReferencePolicy.class);
 
-  @Nonnull
+  @NonNull
   private final IIdentifierParser identifierParser;
 
   protected AbstractCustomReferencePolicy(
-      @Nonnull IIdentifierParser identifierParser) {
+      @NonNull IIdentifierParser identifierParser) {
     this.identifierParser = identifierParser;
   }
 
   @Override
-  @Nonnull
+  @NonNull
   public IIdentifierParser getIdentifierParser() {
     return identifierParser;
   }
@@ -64,13 +65,25 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    *          the reference object
    * @return a list of item types to search for
    */
-  @Nonnull
-  protected abstract List<@Nonnull ItemType> getEntityItemTypes(@Nonnull TYPE reference);
+  @NonNull
+  protected abstract List<ItemType> getEntityItemTypes(@NonNull TYPE reference);
 
+  /**
+   * Handle an index hit.
+   * 
+   * @param reference
+   *          the identifier reference object generating the hit
+   * @param item
+   *          the referenced item
+   * @param visitor
+   *          the reference visitor, which can be used for further processing
+   * @return {@code true} if the hit was handled or {@code false} otherwise
+   * @throw ProfileResolutionEvaluationException if there was an error handing the index hit
+   */
   protected boolean handleIndexHit(
-      @Nonnull TYPE reference,
-      @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull TYPE reference,
+      @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
 
     if (item.isSelected(visitor.getIndex())) {
       if (item.getReferenceCount() == 0 && !item.isResolved()) {
@@ -95,55 +108,126 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
     return true;
   }
 
-  protected void handleUnselected( // NOPMD - intentional
-      @Nonnull TYPE reference,
-      @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+  /**
+   * Handle an index hit against an item related to an unselected control.
+   * <p>
+   * Subclasses can override this method to perform extra processing.
+   * 
+   * @param reference
+   *          the identifier reference object generating the hit
+   * @param item
+   *          the referenced item
+   * @param visitor
+   *          the reference visitor, which can be used for further processing
+   * @throw ProfileResolutionEvaluationException if there was an error handing the index hit
+   */
+  protected void handleUnselected( // NOPMD - do nothing by default
+      @NonNull TYPE reference,
+      @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
     // do nothing by default
   }
 
-  protected void handleSelected( // NOPMD - intentional
-      @Nonnull TYPE reference,
-      @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+  /**
+   * Handle an index hit against an item related to an selected control.
+   * <p>
+   * Subclasses can override this method to perform extra processing.
+   * 
+   * @param reference
+   *          the identifier reference object generating the hit
+   * @param item
+   *          the referenced item
+   * @param visitor
+   *          the reference visitor, which can be used for further processing
+   * @throw ProfileResolutionEvaluationException if there was an error handing the index hit
+   */
+  protected void handleSelected( // NOPMD - do nothing by default
+      @NonNull TYPE reference,
+      @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
     // do nothing by default
   }
 
+  /**
+   * Handle an index miss for a reference. This occurs when the referenced item was not found in the
+   * index.
+   * <p>
+   * Subclasses can override this method to perform extra processing.
+   * 
+   * @param reference
+   *          the identifier reference object generating the hit
+   * @param itemTypes
+   *          the possible item types for this reference
+   * @param identifier
+   *          the parsed identifier
+   * @param visitor
+   *          the reference visitor, which can be used for further processing
+   * @return {@code true} if the reference is handled by this method or {@code false} otherwise
+   * @throw ProfileResolutionEvaluationException if there was an error handing the index miss
+   */
   protected boolean handleIndexMiss(
-      @Nonnull TYPE reference,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull TYPE reference,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor) {
     // provide no handler by default
     return false;
   }
 
+  /**
+   * Handle the case where the identifier was not a syntax match for an expected identifier. This can
+   * occur when the reference is malformed, using an unrecognized syntax.
+   * <p>
+   * Subclasses can override this method to perform extra processing.
+   * 
+   * @param reference
+   *          the identifier reference object generating the hit
+   * @param visitor
+   *          the reference visitor, which can be used for further processing
+   * @return {@code true} if the reference is handled by this method or {@code false} otherwise
+   * @throw ProfileResolutionEvaluationException if there was an error handing the index miss due to a
+   *        non match
+   */
   protected boolean handleIdentifierNonMatch(
-      @Nonnull TYPE reference,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull TYPE reference,
+      @NonNull IReferenceVisitor visitor) {
     // provide no handler by default
     return false;
   }
 
   @Override
-  public boolean handleReference(@Nonnull TYPE type, @Nonnull IReferenceVisitor visitor) {
+  public boolean handleReference(@NonNull TYPE type, @NonNull IReferenceVisitor visitor) {
     String referenceText = getReferenceText(type);
 
     // if the reference text does not exist, ignore the reference; otherwise, handle it.
     return referenceText == null || handleIdentifier(type, getIdentifierParser().parse(referenceText), visitor);
   }
 
+  /**
+   * Handle the provided {@code identifier} for a given {@code type} of reference.
+   * 
+   * @param type
+   *          the item type of the reference
+   * @param identifier
+   *          the identifier
+   * @param visitor
+   *          the reference visitor, which can be used for further processing
+   * @return {@code true} if the reference is handled by this method or {@code false} otherwise
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
   protected boolean handleIdentifier(
-      @Nonnull TYPE type,
+      @NonNull TYPE type,
       @Nullable String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull IReferenceVisitor visitor) {
     boolean retval;
     if (identifier == null) {
       retval = handleIdentifierNonMatch(type, visitor);
     } else {
-      List<@Nonnull ItemType> itemTypes = getEntityItemTypes(type);
+      List<ItemType> itemTypes = getEntityItemTypes(type);
       EntityItem item = null;
       for (ItemType itemType : itemTypes) {
+        assert itemType != null;
+
         item = visitor.getIndex().getEntity(itemType, identifier);
         if (item != null) {
           break;

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractCustomReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractCustomReferencePolicy.java
@@ -32,7 +32,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -40,16 +40,16 @@ import java.util.List;
 public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomReferencePolicy<TYPE> {
   private static final Logger LOGGER = LogManager.getLogger(AbstractCustomReferencePolicy.class);
 
-  @NotNull
+  @Nonnull
   private final IIdentifierParser identifierParser;
 
   protected AbstractCustomReferencePolicy(
-      @NotNull IIdentifierParser identifierParser) {
+      @Nonnull IIdentifierParser identifierParser) {
     this.identifierParser = identifierParser;
   }
 
   @Override
-  @NotNull
+  @Nonnull
   public IIdentifierParser getIdentifierParser() {
     return identifierParser;
   }
@@ -64,13 +64,13 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    *          the reference object
    * @return a list of item types to search for
    */
-  @NotNull
-  protected abstract List<@NotNull ItemType> getEntityItemTypes(@NotNull TYPE reference);
+  @Nonnull
+  protected abstract List<@Nonnull ItemType> getEntityItemTypes(@Nonnull TYPE reference);
 
   protected boolean handleIndexHit(
-      @NotNull TYPE reference,
-      @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull TYPE reference,
+      @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
 
     if (item.isSelected(visitor.getIndex())) {
       if (item.getReferenceCount() == 0 && !item.isResolved()) {
@@ -96,37 +96,37 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
   }
 
   protected void handleUnselected( // NOPMD - intentional
-      @NotNull TYPE reference,
-      @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull TYPE reference,
+      @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
     // do nothing by default
   }
 
   protected void handleSelected( // NOPMD - intentional
-      @NotNull TYPE reference,
-      @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull TYPE reference,
+      @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
     // do nothing by default
   }
 
   protected boolean handleIndexMiss(
-      @NotNull TYPE reference,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull TYPE reference,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor) {
     // provide no handler by default
     return false;
   }
 
   protected boolean handleIdentifierNonMatch(
-      @NotNull TYPE reference,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull TYPE reference,
+      @Nonnull IReferenceVisitor visitor) {
     // provide no handler by default
     return false;
   }
 
   @Override
-  public boolean handleReference(@NotNull TYPE type, @NotNull IReferenceVisitor visitor) {
+  public boolean handleReference(@Nonnull TYPE type, @Nonnull IReferenceVisitor visitor) {
     String referenceText = getReferenceText(type);
 
     // if the reference text does not exist, ignore the reference; otherwise, handle it.
@@ -134,14 +134,14 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
   }
 
   protected boolean handleIdentifier(
-      @NotNull TYPE type,
+      @Nonnull TYPE type,
       @Nullable String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull IReferenceVisitor visitor) {
     boolean retval;
     if (identifier == null) {
       retval = handleIdentifierNonMatch(type, visitor);
     } else {
-      List<@NotNull ItemType> itemTypes = getEntityItemTypes(type);
+      List<@Nonnull ItemType> itemTypes = getEntityItemTypes(type);
       EntityItem item = null;
       for (ItemType itemType : itemTypes) {
         item = visitor.getIndex().getEntity(itemType, identifier);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractIndexMissPolicyHandler.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractIndexMissPolicyHandler.java
@@ -28,16 +28,16 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 
 public abstract class AbstractIndexMissPolicyHandler<TYPE> implements ICustomReferencePolicyHandler<TYPE> {
   @Override
   public abstract boolean handleIndexMiss(
-      @NotNull ICustomReferencePolicy<TYPE> policy,
-      @NotNull TYPE type,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor);
+      @Nonnull ICustomReferencePolicy<TYPE> policy,
+      @Nonnull TYPE type,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractIndexMissPolicyHandler.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractIndexMissPolicyHandler.java
@@ -28,16 +28,16 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.List;
 
 public abstract class AbstractIndexMissPolicyHandler<TYPE> implements ICustomReferencePolicyHandler<TYPE> {
   @Override
   public abstract boolean handleIndexMiss(
-      @Nonnull ICustomReferencePolicy<TYPE> policy,
-      @Nonnull TYPE type,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor);
+      @NonNull ICustomReferencePolicy<TYPE> policy,
+      @NonNull TYPE type,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractMultiItemTypeReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractMultiItemTypeReferencePolicy.java
@@ -29,25 +29,25 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 
 public abstract class AbstractMultiItemTypeReferencePolicy<TYPE>
     extends AbstractCustomReferencePolicy<TYPE> {
 
-  @NotNull
-  private final List<@NotNull ItemType> itemTypes;
+  @Nonnull
+  private final List<@Nonnull ItemType> itemTypes;
 
   public AbstractMultiItemTypeReferencePolicy(
-      @NotNull IIdentifierParser identifierParser,
-      @NotNull List<@NotNull ItemType> itemTypes) {
+      @Nonnull IIdentifierParser identifierParser,
+      @Nonnull List<@Nonnull ItemType> itemTypes) {
     super(identifierParser);
     this.itemTypes = CollectionUtil.requireNonEmpty(itemTypes, "itemTypes");
   }
 
   @Override
-  protected List<@NotNull ItemType> getEntityItemTypes(@NotNull TYPE type) {
+  protected List<@Nonnull ItemType> getEntityItemTypes(@Nonnull TYPE type) {
     return itemTypes;
   }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractMultiItemTypeReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractMultiItemTypeReferencePolicy.java
@@ -29,25 +29,25 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.List;
 
 public abstract class AbstractMultiItemTypeReferencePolicy<TYPE>
     extends AbstractCustomReferencePolicy<TYPE> {
 
-  @Nonnull
-  private final List<@Nonnull ItemType> itemTypes;
+  @NonNull
+  private final List<ItemType> itemTypes;
 
   public AbstractMultiItemTypeReferencePolicy(
-      @Nonnull IIdentifierParser identifierParser,
-      @Nonnull List<@Nonnull ItemType> itemTypes) {
+      @NonNull IIdentifierParser identifierParser,
+      @NonNull List<ItemType> itemTypes) {
     super(identifierParser);
     this.itemTypes = CollectionUtil.requireNonEmpty(itemTypes, "itemTypes");
   }
 
   @Override
-  protected List<@Nonnull ItemType> getEntityItemTypes(@Nonnull TYPE type) {
+  protected List<ItemType> getEntityItemTypes(@NonNull TYPE type) {
     return itemTypes;
   }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AnchorReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AnchorReferencePolicy.java
@@ -36,7 +36,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
@@ -52,23 +52,23 @@ public class AnchorReferencePolicy
 
   @SuppressWarnings("null")
   @Override
-  protected List<@NotNull ItemType> getEntityItemTypes(@NotNull InlineLinkNode link) {
+  protected List<@Nonnull ItemType> getEntityItemTypes(@Nonnull InlineLinkNode link) {
     return List.of(ItemType.RESOURCE, ItemType.CONTROL, ItemType.GROUP, ItemType.PART);
   }
 
   @Override
-  public String getReferenceText(@NotNull InlineLinkNode link) {
+  public String getReferenceText(@Nonnull InlineLinkNode link) {
     return link.getUrl().toString();
   }
 
   @Override
-  public void setReferenceText(@NotNull InlineLinkNode link, @NotNull String newValue) {
+  public void setReferenceText(@Nonnull InlineLinkNode link, @Nonnull String newValue) {
     link.setUrl(BasedSequence.of(newValue));
   }
 
   @Override
-  protected void handleUnselected(@NotNull InlineLinkNode link, @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+  protected void handleUnselected(@Nonnull InlineLinkNode link, @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
     URI linkHref = URI.create(link.getUrl().toString());
     URI sourceUri = item.getSource();
 
@@ -81,10 +81,10 @@ public class AnchorReferencePolicy
 
   @Override
   protected boolean handleIndexMiss(
-      @NotNull InlineLinkNode reference,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull InlineLinkNode reference,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor) {
     if (LOGGER.isErrorEnabled()) {
       LOGGER.atError().log(
           "the anchor should reference a {} identified by '{}', but the identifier was not found in the index.",
@@ -97,7 +97,7 @@ public class AnchorReferencePolicy
   }
 
   @Override
-  protected boolean handleIdentifierNonMatch(@NotNull InlineLinkNode reference, @NotNull IReferenceVisitor visitor) {
+  protected boolean handleIdentifierNonMatch(@Nonnull InlineLinkNode reference, @Nonnull IReferenceVisitor visitor) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("Ignoring URI '{}'", reference.getUrl().toStringOrNull());
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AnchorReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AnchorReferencePolicy.java
@@ -36,11 +36,12 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class AnchorReferencePolicy
     extends AbstractCustomReferencePolicy<InlineLinkNode> {
@@ -52,23 +53,23 @@ public class AnchorReferencePolicy
 
   @SuppressWarnings("null")
   @Override
-  protected List<@Nonnull ItemType> getEntityItemTypes(@Nonnull InlineLinkNode link) {
+  protected List<ItemType> getEntityItemTypes(@NonNull InlineLinkNode link) {
     return List.of(ItemType.RESOURCE, ItemType.CONTROL, ItemType.GROUP, ItemType.PART);
   }
 
   @Override
-  public String getReferenceText(@Nonnull InlineLinkNode link) {
+  public String getReferenceText(@NonNull InlineLinkNode link) {
     return link.getUrl().toString();
   }
 
   @Override
-  public void setReferenceText(@Nonnull InlineLinkNode link, @Nonnull String newValue) {
+  public void setReferenceText(@NonNull InlineLinkNode link, @NonNull String newValue) {
     link.setUrl(BasedSequence.of(newValue));
   }
 
   @Override
-  protected void handleUnselected(@Nonnull InlineLinkNode link, @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+  protected void handleUnselected(@NonNull InlineLinkNode link, @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
     URI linkHref = URI.create(link.getUrl().toString());
     URI sourceUri = item.getSource();
 
@@ -81,10 +82,10 @@ public class AnchorReferencePolicy
 
   @Override
   protected boolean handleIndexMiss(
-      @Nonnull InlineLinkNode reference,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull InlineLinkNode reference,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor) {
     if (LOGGER.isErrorEnabled()) {
       LOGGER.atError().log(
           "the anchor should reference a {} identified by '{}', but the identifier was not found in the index.",
@@ -97,7 +98,7 @@ public class AnchorReferencePolicy
   }
 
   @Override
-  protected boolean handleIdentifierNonMatch(@Nonnull InlineLinkNode reference, @Nonnull IReferenceVisitor visitor) {
+  protected boolean handleIdentifierNonMatch(@NonNull InlineLinkNode reference, @NonNull IReferenceVisitor visitor) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("Ignoring URI '{}'", reference.getUrl().toStringOrNull());
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicy.java
@@ -26,7 +26,7 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
 
@@ -35,7 +35,7 @@ public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
    * 
    * @return the parser
    */
-  @NotNull
+  @Nonnull
   IIdentifierParser getIdentifierParser();
 
   /**
@@ -45,7 +45,7 @@ public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
    *          the reference object
    * @return the reference text or {@code null} if there is no text
    */
-  String getReferenceText(@NotNull TYPE reference);
+  String getReferenceText(@Nonnull TYPE reference);
 
   /**
    * Update the reference text used in the {@code reference} object.
@@ -55,5 +55,5 @@ public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
    * @param newReferenceText
    *          the reference text replacement
    */
-  void setReferenceText(@NotNull TYPE reference, @NotNull String newReferenceText);
+  void setReferenceText(@Nonnull TYPE reference, @Nonnull String newReferenceText);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicyHandler.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicyHandler.java
@@ -29,20 +29,20 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 
 public interface ICustomReferencePolicyHandler<TYPE> {
-  @NotNull
+  @Nonnull
   ICustomReferencePolicyHandler<?> IGNORE_INDEX_MISS_POLICY = new AbstractIndexMissPolicyHandler<>() {
     @Override
     public boolean handleIndexMiss(
-        @NotNull ICustomReferencePolicy<Object> policy,
-        @NotNull Object type,
-        @NotNull List<@NotNull ItemType> itemTypes,
-        @NotNull String identifier,
-        @NotNull IReferenceVisitor visitor) {
+        @Nonnull ICustomReferencePolicy<Object> policy,
+        @Nonnull Object type,
+        @Nonnull List<@Nonnull ItemType> itemTypes,
+        @Nonnull String identifier,
+        @Nonnull IReferenceVisitor visitor) {
       // do nothing
       return true;
     }
@@ -61,9 +61,9 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    * @return {@code true} if the reference is considered handled, or {@code false} otherwise
    */
   default boolean handleIdentifierNonMatch(
-      @NotNull ICustomReferencePolicy<TYPE> policy,
-      @NotNull TYPE reference,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull ICustomReferencePolicy<TYPE> policy,
+      @Nonnull TYPE reference,
+      @Nonnull IReferenceVisitor visitor) {
     return false;
   }
 
@@ -84,11 +84,11 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    * @return {@code true} if the reference is considered handled, or {@code false} otherwise
    */
   default boolean handleIndexMiss(
-      @NotNull ICustomReferencePolicy<TYPE> policy,
-      @NotNull TYPE reference,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull ICustomReferencePolicy<TYPE> policy,
+      @Nonnull TYPE reference,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor) {
     return false;
   }
 
@@ -107,10 +107,10 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    * @return {@code true} if the reference is considered handled, or {@code false} otherwise
    */
   default boolean handleIndexHit(
-      @NotNull ICustomReferencePolicy<TYPE> policy,
-      @NotNull TYPE reference,
-      @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull ICustomReferencePolicy<TYPE> policy,
+      @Nonnull TYPE reference,
+      @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
     return false;
   }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicyHandler.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicyHandler.java
@@ -29,20 +29,20 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.List;
 
 public interface ICustomReferencePolicyHandler<TYPE> {
-  @Nonnull
+  @NonNull
   ICustomReferencePolicyHandler<?> IGNORE_INDEX_MISS_POLICY = new AbstractIndexMissPolicyHandler<>() {
     @Override
     public boolean handleIndexMiss(
-        @Nonnull ICustomReferencePolicy<Object> policy,
-        @Nonnull Object type,
-        @Nonnull List<@Nonnull ItemType> itemTypes,
-        @Nonnull String identifier,
-        @Nonnull IReferenceVisitor visitor) {
+        @NonNull ICustomReferencePolicy<Object> policy,
+        @NonNull Object type,
+        @NonNull List<ItemType> itemTypes,
+        @NonNull String identifier,
+        @NonNull IReferenceVisitor visitor) {
       // do nothing
       return true;
     }
@@ -61,9 +61,9 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    * @return {@code true} if the reference is considered handled, or {@code false} otherwise
    */
   default boolean handleIdentifierNonMatch(
-      @Nonnull ICustomReferencePolicy<TYPE> policy,
-      @Nonnull TYPE reference,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull ICustomReferencePolicy<TYPE> policy,
+      @NonNull TYPE reference,
+      @NonNull IReferenceVisitor visitor) {
     return false;
   }
 
@@ -84,11 +84,11 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    * @return {@code true} if the reference is considered handled, or {@code false} otherwise
    */
   default boolean handleIndexMiss(
-      @Nonnull ICustomReferencePolicy<TYPE> policy,
-      @Nonnull TYPE reference,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull ICustomReferencePolicy<TYPE> policy,
+      @NonNull TYPE reference,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor) {
     return false;
   }
 
@@ -107,10 +107,10 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    * @return {@code true} if the reference is considered handled, or {@code false} otherwise
    */
   default boolean handleIndexHit(
-      @Nonnull ICustomReferencePolicy<TYPE> policy,
-      @Nonnull TYPE reference,
-      @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull ICustomReferencePolicy<TYPE> policy,
+      @NonNull TYPE reference,
+      @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
     return false;
   }
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IIdentifierParser.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IIdentifierParser.java
@@ -26,22 +26,22 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.Nullable;
 
 public interface IIdentifierParser {
-  @NotNull
+  @Nonnull
   IIdentifierParser FRAGMENT_PARSER = new PatternIdentifierParser("^#([^#]+)(?:#.*)?$", 1);
-  @NotNull
+  @Nonnull
   IIdentifierParser IDENTITY_PARSER = new IIdentifierParser() {
 
     @Override
-    public String parse(@NotNull String reference) {
+    public String parse(@Nonnull String reference) {
       return reference;
     }
 
     @Override
-    public String update(@NotNull String reference, @NotNull String newIdentifier) {
+    public String update(@Nonnull String reference, @Nonnull String newIdentifier) {
       return newIdentifier;
     }
   };
@@ -54,7 +54,7 @@ public interface IIdentifierParser {
    * @return the identifier, or {@code null} if the identifier could not be parsed
    */
   @Nullable
-  String parse(@NotNull String referenceText);
+  String parse(@Nonnull String referenceText);
 
   /**
    * Substitute the provided {@code newIdentifier} with the identifier in the {@code referenceText}.
@@ -65,6 +65,6 @@ public interface IIdentifierParser {
    *          the new identifier to replace the existing identifier
    * @return the updated reference text with the identifier replaced
    */
-  @NotNull
-  String update(@NotNull String referenceText, @NotNull String newIdentifier);
+  @Nonnull
+  String update(@Nonnull String referenceText, @Nonnull String newIdentifier);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IIdentifierParser.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IIdentifierParser.java
@@ -26,22 +26,24 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
-import javax.annotation.Nonnull;
-import org.jetbrains.annotations.Nullable;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionEvaluationException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public interface IIdentifierParser {
-  @Nonnull
+  @NonNull
   IIdentifierParser FRAGMENT_PARSER = new PatternIdentifierParser("^#([^#]+)(?:#.*)?$", 1);
-  @Nonnull
+  @NonNull
   IIdentifierParser IDENTITY_PARSER = new IIdentifierParser() {
 
     @Override
-    public String parse(@Nonnull String reference) {
+    public String parse(@NonNull String reference) {
       return reference;
     }
 
     @Override
-    public String update(@Nonnull String reference, @Nonnull String newIdentifier) {
+    public String update(@NonNull String reference, @NonNull String newIdentifier) {
       return newIdentifier;
     }
   };
@@ -54,7 +56,7 @@ public interface IIdentifierParser {
    * @return the identifier, or {@code null} if the identifier could not be parsed
    */
   @Nullable
-  String parse(@Nonnull String referenceText);
+  String parse(@NonNull String referenceText);
 
   /**
    * Substitute the provided {@code newIdentifier} with the identifier in the {@code referenceText}.
@@ -64,7 +66,8 @@ public interface IIdentifierParser {
    * @param newIdentifier
    *          the new identifier to replace the existing identifier
    * @return the updated reference text with the identifier replaced
+   * @throws ProfileResolutionEvaluationException if the identifier could not be updated
    */
-  @Nonnull
-  String update(@Nonnull String referenceText, @Nonnull String newIdentifier);
+  @NonNull
+  String update(@NonNull String referenceText, @NonNull String newIdentifier);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferencePolicy.java
@@ -26,14 +26,14 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface IReferencePolicy<T> {
-  @Nonnull
+  @NonNull
   IReferencePolicy<Object> IGNORE_POLICY = new IReferencePolicy<>() {
 
     @Override
-    public boolean handleReference(@Nonnull Object reference, @Nonnull IReferenceVisitor visitor) {
+    public boolean handleReference(@NonNull Object reference, @NonNull IReferenceVisitor visitor) {
       return true;
     }
   };
@@ -46,9 +46,9 @@ public interface IReferencePolicy<T> {
    * @return the policy
    */
   @SuppressWarnings("unchecked")
-  @Nonnull
+  @NonNull
   static <T> IReferencePolicy<T> ignore() {
-    return (@Nonnull IReferencePolicy<T>) IGNORE_POLICY;
+    return (IReferencePolicy<T>) IGNORE_POLICY;
   }
 
   /**
@@ -59,6 +59,7 @@ public interface IReferencePolicy<T> {
    * @param visitor
    *          used to lookup and resolve items
    * @return {@code true} if the reference was handled, or {@code false} otherwise
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
    */
-  boolean handleReference(@Nonnull T reference, @Nonnull IReferenceVisitor visitor);
+  boolean handleReference(@NonNull T reference, @NonNull IReferenceVisitor visitor);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferencePolicy.java
@@ -26,14 +26,14 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public interface IReferencePolicy<T> {
-  @NotNull
+  @Nonnull
   IReferencePolicy<Object> IGNORE_POLICY = new IReferencePolicy<>() {
 
     @Override
-    public boolean handleReference(@NotNull Object reference, @NotNull IReferenceVisitor visitor) {
+    public boolean handleReference(@Nonnull Object reference, @Nonnull IReferenceVisitor visitor) {
       return true;
     }
   };
@@ -46,9 +46,9 @@ public interface IReferencePolicy<T> {
    * @return the policy
    */
   @SuppressWarnings("unchecked")
-  @NotNull
+  @Nonnull
   static <T> IReferencePolicy<T> ignore() {
-    return (@NotNull IReferencePolicy<T>) IGNORE_POLICY;
+    return (@Nonnull IReferencePolicy<T>) IGNORE_POLICY;
   }
 
   /**
@@ -60,5 +60,5 @@ public interface IReferencePolicy<T> {
    *          used to lookup and resolve items
    * @return {@code true} if the reference was handled, or {@code false} otherwise
    */
-  boolean handleReference(@NotNull T reference, @NotNull IReferenceVisitor visitor);
+  boolean handleReference(@Nonnull T reference, @Nonnull IReferenceVisitor visitor);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferenceVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferenceVisitor.java
@@ -27,27 +27,100 @@
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
+import gov.nist.secauto.oscal.lib.model.BackMatter.Resource;
+import gov.nist.secauto.oscal.lib.model.CatalogGroup;
+import gov.nist.secauto.oscal.lib.model.Control;
+import gov.nist.secauto.oscal.lib.model.ControlPart;
+import gov.nist.secauto.oscal.lib.model.Location;
+import gov.nist.secauto.oscal.lib.model.Parameter;
+import gov.nist.secauto.oscal.lib.model.Party;
+import gov.nist.secauto.oscal.lib.model.Role;
 import gov.nist.secauto.oscal.lib.profile.resolver.Index;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface IReferenceVisitor {
-  @Nonnull
+  @NonNull
   Index getIndex();
 
-  void visitGroup(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link CatalogGroup} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitGroup(@NonNull IRequiredValueModelNodeItem item);
 
-  void visitControl(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link Control} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitControl(@NonNull IRequiredValueModelNodeItem item);
 
-  void visitParameter(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link Parameter} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitParameter(@NonNull IRequiredValueModelNodeItem item);
 
-  void visitPart(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitRole(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link ControlPart} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitPart(@NonNull IRequiredValueModelNodeItem item);
 
-  void visitParty(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link Role} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitRole(@NonNull IRequiredValueModelNodeItem item);
 
-  void visitLocation(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link Party} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitParty(@NonNull IRequiredValueModelNodeItem item);
 
-  void visitResource(@Nonnull IRequiredValueModelNodeItem item);
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link Location} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitLocation(@NonNull IRequiredValueModelNodeItem item);
+
+  /**
+   * Visit the provided {@code item} representing an OSCAL {@link Resource} and handle any
+   * enclosed references.
+   * 
+   * @param item
+   *          the Metapath node item containing reference nodes
+   * @throw ProfileResolutionEvaluationException if there was an error handing the reference
+   */
+  void visitResource(@NonNull IRequiredValueModelNodeItem item);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferenceVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferenceVisitor.java
@@ -29,25 +29,25 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 import gov.nist.secauto.oscal.lib.profile.resolver.Index;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public interface IReferenceVisitor {
-  @NotNull
+  @Nonnull
   Index getIndex();
 
-  void visitGroup(@NotNull IRequiredValueModelNodeItem item);
+  void visitGroup(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitControl(@NotNull IRequiredValueModelNodeItem item);
+  void visitControl(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitParameter(@NotNull IRequiredValueModelNodeItem item);
+  void visitParameter(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitPart(@NotNull IRequiredValueModelNodeItem item);
+  void visitPart(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitRole(@NotNull IRequiredValueModelNodeItem item);
+  void visitRole(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitParty(@NotNull IRequiredValueModelNodeItem item);
+  void visitParty(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitLocation(@NotNull IRequiredValueModelNodeItem item);
+  void visitLocation(@Nonnull IRequiredValueModelNodeItem item);
 
-  void visitResource(@NotNull IRequiredValueModelNodeItem item);
+  void visitResource(@Nonnull IRequiredValueModelNodeItem item);
 }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/InsertReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/InsertReferencePolicy.java
@@ -35,7 +35,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.Locale;
@@ -49,10 +49,10 @@ public class InsertReferencePolicy
   }
 
   @Override
-  protected List<@NotNull ItemType> getEntityItemTypes(@NotNull InsertAnchorNode insert) {
+  protected List<@Nonnull ItemType> getEntityItemTypes(@Nonnull InsertAnchorNode insert) {
     String type = insert.getType().toString();
 
-    List<@NotNull ItemType> itemTypes;
+    List<@Nonnull ItemType> itemTypes;
     if ("param".equals(type)) {
       itemTypes = CollectionUtil.singletonList(ItemType.PARAMETER);
     } else {
@@ -62,21 +62,21 @@ public class InsertReferencePolicy
   }
 
   @Override
-  public String getReferenceText(@NotNull InsertAnchorNode insert) {
+  public String getReferenceText(@Nonnull InsertAnchorNode insert) {
     return insert.getIdReference().toString();
   }
 
   @Override
-  public void setReferenceText(@NotNull InsertAnchorNode insert, @NotNull String newReference) {
+  public void setReferenceText(@Nonnull InsertAnchorNode insert, @Nonnull String newReference) {
     insert.setIdReference(BasedSequence.of(newReference));
   }
 
   @Override
   protected boolean handleIndexMiss(
-      @NotNull InsertAnchorNode insert,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull InsertAnchorNode insert,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor) {
     if (LOGGER.isErrorEnabled()) {
       LOGGER.atError().log(
           "the '{}' insert should reference a '{}' identified by '{}'. The index did not contain the identifier.",

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/InsertReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/InsertReferencePolicy.java
@@ -35,10 +35,11 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.Locale;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class InsertReferencePolicy
     extends AbstractCustomReferencePolicy<InsertAnchorNode> {
@@ -49,10 +50,10 @@ public class InsertReferencePolicy
   }
 
   @Override
-  protected List<@Nonnull ItemType> getEntityItemTypes(@Nonnull InsertAnchorNode insert) {
+  protected List<ItemType> getEntityItemTypes(@NonNull InsertAnchorNode insert) {
     String type = insert.getType().toString();
 
-    List<@Nonnull ItemType> itemTypes;
+    List<ItemType> itemTypes;
     if ("param".equals(type)) {
       itemTypes = CollectionUtil.singletonList(ItemType.PARAMETER);
     } else {
@@ -62,21 +63,21 @@ public class InsertReferencePolicy
   }
 
   @Override
-  public String getReferenceText(@Nonnull InsertAnchorNode insert) {
+  public String getReferenceText(@NonNull InsertAnchorNode insert) {
     return insert.getIdReference().toString();
   }
 
   @Override
-  public void setReferenceText(@Nonnull InsertAnchorNode insert, @Nonnull String newReference) {
+  public void setReferenceText(@NonNull InsertAnchorNode insert, @NonNull String newReference) {
     insert.setIdReference(BasedSequence.of(newReference));
   }
 
   @Override
   protected boolean handleIndexMiss(
-      @Nonnull InsertAnchorNode insert,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull InsertAnchorNode insert,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor) {
     if (LOGGER.isErrorEnabled()) {
       LOGGER.atError().log(
           "the '{}' insert should reference a '{}' identified by '{}'. The index did not contain the identifier.",

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/LinkReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/LinkReferencePolicy.java
@@ -34,7 +34,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
@@ -45,35 +45,35 @@ public class LinkReferencePolicy
   private static final Logger LOGGER = LogManager.getLogger(LinkReferencePolicy.class);
 
   @SuppressWarnings("null")
-  @NotNull
-  public static LinkReferencePolicy create(@NotNull ItemType itemType) {
+  @Nonnull
+  public static LinkReferencePolicy create(@Nonnull ItemType itemType) {
     return create(List.of(itemType));
   }
 
-  @NotNull
-  public static LinkReferencePolicy create(@NotNull List<@NotNull ItemType> itemTypes) {
+  @Nonnull
+  public static LinkReferencePolicy create(@Nonnull List<@Nonnull ItemType> itemTypes) {
     return new LinkReferencePolicy(CollectionUtil.requireNonEmpty(itemTypes, "itemTypes"));
   }
 
-  public LinkReferencePolicy(@NotNull List<@NotNull ItemType> itemTypes) {
+  public LinkReferencePolicy(@Nonnull List<@Nonnull ItemType> itemTypes) {
     super(IIdentifierParser.FRAGMENT_PARSER, itemTypes);
   }
 
   @Override
-  public String getReferenceText(@NotNull Link link) {
+  public String getReferenceText(@Nonnull Link link) {
     return link.getHref().toString();
   }
 
   @Override
-  public void setReferenceText(@NotNull Link link, @NotNull String newValue) {
+  public void setReferenceText(@Nonnull Link link, @Nonnull String newValue) {
     link.setHref(URI.create(newValue));
   }
 
   @Override
   protected void handleUnselected(
-      @NotNull Link link,
-      @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull Link link,
+      @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
     URI linkHref = link.getHref();
     URI sourceUri = item.getSource();
 
@@ -86,10 +86,10 @@ public class LinkReferencePolicy
 
   @Override
   protected boolean handleIndexMiss(
-      @NotNull Link link,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull Link link,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor) {
     if (LOGGER.isWarnEnabled()) {
       LOGGER.atWarn().log(
           "link with rel '{}' should reference a {} identified by '{}'. The index did not contain the identifier.",
@@ -103,7 +103,7 @@ public class LinkReferencePolicy
   }
 
   @Override
-  protected boolean handleIdentifierNonMatch(@NotNull Link reference, @NotNull IReferenceVisitor visitor) {
+  protected boolean handleIdentifierNonMatch(@Nonnull Link reference, @Nonnull IReferenceVisitor visitor) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("Ignoring URI '{}'", reference.getHref().toString());
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/LinkReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/LinkReferencePolicy.java
@@ -34,46 +34,47 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class LinkReferencePolicy
     extends AbstractMultiItemTypeReferencePolicy<Link> {
   private static final Logger LOGGER = LogManager.getLogger(LinkReferencePolicy.class);
 
   @SuppressWarnings("null")
-  @Nonnull
-  public static LinkReferencePolicy create(@Nonnull ItemType itemType) {
+  @NonNull
+  public static LinkReferencePolicy create(@NonNull ItemType itemType) {
     return create(List.of(itemType));
   }
 
-  @Nonnull
-  public static LinkReferencePolicy create(@Nonnull List<@Nonnull ItemType> itemTypes) {
+  @NonNull
+  public static LinkReferencePolicy create(@NonNull List<ItemType> itemTypes) {
     return new LinkReferencePolicy(CollectionUtil.requireNonEmpty(itemTypes, "itemTypes"));
   }
 
-  public LinkReferencePolicy(@Nonnull List<@Nonnull ItemType> itemTypes) {
+  public LinkReferencePolicy(@NonNull List<ItemType> itemTypes) {
     super(IIdentifierParser.FRAGMENT_PARSER, itemTypes);
   }
 
   @Override
-  public String getReferenceText(@Nonnull Link link) {
+  public String getReferenceText(@NonNull Link link) {
     return link.getHref().toString();
   }
 
   @Override
-  public void setReferenceText(@Nonnull Link link, @Nonnull String newValue) {
+  public void setReferenceText(@NonNull Link link, @NonNull String newValue) {
     link.setHref(URI.create(newValue));
   }
 
   @Override
   protected void handleUnselected(
-      @Nonnull Link link,
-      @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull Link link,
+      @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
     URI linkHref = link.getHref();
     URI sourceUri = item.getSource();
 
@@ -86,10 +87,10 @@ public class LinkReferencePolicy
 
   @Override
   protected boolean handleIndexMiss(
-      @Nonnull Link link,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull Link link,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor) {
     if (LOGGER.isWarnEnabled()) {
       LOGGER.atWarn().log(
           "link with rel '{}' should reference a {} identified by '{}'. The index did not contain the identifier.",
@@ -103,7 +104,7 @@ public class LinkReferencePolicy
   }
 
   @Override
-  protected boolean handleIdentifierNonMatch(@Nonnull Link reference, @Nonnull IReferenceVisitor visitor) {
+  protected boolean handleIdentifierNonMatch(@NonNull Link reference, @NonNull IReferenceVisitor visitor) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("Ignoring URI '{}'", reference.getHref().toString());
     }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PatternIdentifierParser.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PatternIdentifierParser.java
@@ -28,7 +28,7 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -39,12 +39,12 @@ public class PatternIdentifierParser implements IIdentifierParser {
   private final int identifierGroup;
 
   @SuppressWarnings("null")
-  public PatternIdentifierParser(@NotNull String pattern, int identifierGroup) {
+  public PatternIdentifierParser(@Nonnull String pattern, int identifierGroup) {
     this(Pattern.compile(pattern), identifierGroup);
   }
 
   @SuppressWarnings("null")
-  public PatternIdentifierParser(@NotNull Pattern pattern, int identifierGroup) {
+  public PatternIdentifierParser(@Nonnull Pattern pattern, int identifierGroup) {
     this.pattern = Objects.requireNonNull(pattern, "pattern");
     this.identifierGroup = identifierGroup;
   }
@@ -58,14 +58,14 @@ public class PatternIdentifierParser implements IIdentifierParser {
   }
 
   @Override
-  public String parse(@NotNull String referenceText) {
+  public String parse(@Nonnull String referenceText) {
     Matcher matcher = getPattern().matcher(referenceText);
 
     return matcher.matches() ? matcher.group(getIdentifierGroup()) : null;
   }
 
   @Override
-  public String update(@NotNull String referenceText, @NotNull String newIdentifier) {
+  public String update(@Nonnull String referenceText, @Nonnull String newIdentifier) {
     Matcher matcher = getPattern().matcher(referenceText);
     if (!matcher.matches()) {
       throw new IllegalStateException(String.format("The original reference '%s' did not match the pattern '%s'.",

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PatternIdentifierParser.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PatternIdentifierParser.java
@@ -27,24 +27,24 @@
 package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
-
-import javax.annotation.Nonnull;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionEvaluationException;
 
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class PatternIdentifierParser implements IIdentifierParser {
   private final Pattern pattern;
   private final int identifierGroup;
 
   @SuppressWarnings("null")
-  public PatternIdentifierParser(@Nonnull String pattern, int identifierGroup) {
+  public PatternIdentifierParser(@NonNull String pattern, int identifierGroup) {
     this(Pattern.compile(pattern), identifierGroup);
   }
 
-  @SuppressWarnings("null")
-  public PatternIdentifierParser(@Nonnull Pattern pattern, int identifierGroup) {
+  public PatternIdentifierParser(@NonNull Pattern pattern, int identifierGroup) {
     this.pattern = Objects.requireNonNull(pattern, "pattern");
     this.identifierGroup = identifierGroup;
   }
@@ -58,18 +58,23 @@ public class PatternIdentifierParser implements IIdentifierParser {
   }
 
   @Override
-  public String parse(@Nonnull String referenceText) {
+  public String parse(@NonNull String referenceText) {
     Matcher matcher = getPattern().matcher(referenceText);
 
-    return matcher.matches() ? matcher.group(getIdentifierGroup()) : null;
+    String retval = null;
+    if (matcher.matches()) {
+      retval = matcher.group(getIdentifierGroup());
+    }
+    return retval;
   }
 
   @Override
-  public String update(@Nonnull String referenceText, @Nonnull String newIdentifier) {
+  public String update(@NonNull String referenceText, @NonNull String newIdentifier) {
     Matcher matcher = getPattern().matcher(referenceText);
     if (!matcher.matches()) {
-      throw new IllegalStateException(String.format("The original reference '%s' did not match the pattern '%s'.",
-          referenceText, getPattern().pattern()));
+      throw new ProfileResolutionEvaluationException(
+          String.format("The original reference '%s' did not match the pattern '%s'.",
+              referenceText, getPattern().pattern()));
     }
 
     return ObjectUtils.notNull(new StringBuilder(referenceText)

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PropertyReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PropertyReferencePolicy.java
@@ -33,7 +33,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
@@ -44,38 +44,38 @@ public class PropertyReferencePolicy
   private static final Logger LOGGER = LogManager.getLogger(PropertyReferencePolicy.class);
 
   @SuppressWarnings("null")
-  @NotNull
-  public static PropertyReferencePolicy create(@NotNull IIdentifierParser identifierParser,
-      @NotNull ItemType itemType) {
+  @Nonnull
+  public static PropertyReferencePolicy create(@Nonnull IIdentifierParser identifierParser,
+      @Nonnull ItemType itemType) {
     return create(identifierParser, List.of(itemType));
   }
 
-  @NotNull
-  public static PropertyReferencePolicy create(@NotNull IIdentifierParser identifierParser,
-      @NotNull List<ItemType> itemTypes) {
+  @Nonnull
+  public static PropertyReferencePolicy create(@Nonnull IIdentifierParser identifierParser,
+      @Nonnull List<ItemType> itemTypes) {
     return new PropertyReferencePolicy(identifierParser, itemTypes);
   }
 
   @SuppressWarnings("null")
-  public PropertyReferencePolicy(@NotNull IIdentifierParser identifierParser, @NotNull List<ItemType> itemTypes) {
+  public PropertyReferencePolicy(@Nonnull IIdentifierParser identifierParser, @Nonnull List<ItemType> itemTypes) {
     super(identifierParser, itemTypes);
   }
 
   @Override
-  public String getReferenceText(@NotNull Property property) {
+  public String getReferenceText(@Nonnull Property property) {
     return property.getValue();
   }
 
   @Override
-  public void setReferenceText(@NotNull Property property, @NotNull String newValue) {
+  public void setReferenceText(@Nonnull Property property, @Nonnull String newValue) {
     property.setValue(newValue);
   }
 
   @Override
   protected void handleUnselected(
-      @NotNull Property property,
-      @NotNull EntityItem item,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull Property property,
+      @Nonnull EntityItem item,
+      @Nonnull IReferenceVisitor visitor) {
     URI linkHref = URI.create(property.getValue());
     URI sourceUri = item.getSource();
 
@@ -88,10 +88,10 @@ public class PropertyReferencePolicy
 
   @Override
   protected boolean handleIndexMiss(
-      @NotNull Property property,
-      @NotNull List<@NotNull ItemType> itemTypes,
-      @NotNull String identifier,
-      @NotNull IReferenceVisitor visitor) {
+      @Nonnull Property property,
+      @Nonnull List<@Nonnull ItemType> itemTypes,
+      @Nonnull String identifier,
+      @Nonnull IReferenceVisitor visitor) {
     if (LOGGER.isWarnEnabled()) {
       LOGGER.atWarn().log(
           "property '{}' should reference a {} identified by '{}', but the identifier was not found in the index.",

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PropertyReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/PropertyReferencePolicy.java
@@ -33,49 +33,48 @@ import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public class PropertyReferencePolicy
     extends AbstractMultiItemTypeReferencePolicy<Property> {
   private static final Logger LOGGER = LogManager.getLogger(PropertyReferencePolicy.class);
 
-  @SuppressWarnings("null")
-  @Nonnull
-  public static PropertyReferencePolicy create(@Nonnull IIdentifierParser identifierParser,
-      @Nonnull ItemType itemType) {
+  @NonNull
+  public static PropertyReferencePolicy create(@NonNull IIdentifierParser identifierParser,
+      @NonNull ItemType itemType) {
     return create(identifierParser, List.of(itemType));
   }
 
-  @Nonnull
-  public static PropertyReferencePolicy create(@Nonnull IIdentifierParser identifierParser,
-      @Nonnull List<ItemType> itemTypes) {
+  @NonNull
+  public static PropertyReferencePolicy create(@NonNull IIdentifierParser identifierParser,
+      @NonNull List<ItemType> itemTypes) {
     return new PropertyReferencePolicy(identifierParser, itemTypes);
   }
 
-  @SuppressWarnings("null")
-  public PropertyReferencePolicy(@Nonnull IIdentifierParser identifierParser, @Nonnull List<ItemType> itemTypes) {
+  public PropertyReferencePolicy(@NonNull IIdentifierParser identifierParser, @NonNull List<ItemType> itemTypes) {
     super(identifierParser, itemTypes);
   }
 
   @Override
-  public String getReferenceText(@Nonnull Property property) {
+  public String getReferenceText(@NonNull Property property) {
     return property.getValue();
   }
 
   @Override
-  public void setReferenceText(@Nonnull Property property, @Nonnull String newValue) {
+  public void setReferenceText(@NonNull Property property, @NonNull String newValue) {
     property.setValue(newValue);
   }
 
   @Override
   protected void handleUnselected(
-      @Nonnull Property property,
-      @Nonnull EntityItem item,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull Property property,
+      @NonNull EntityItem item,
+      @NonNull IReferenceVisitor visitor) {
     URI linkHref = URI.create(property.getValue());
     URI sourceUri = item.getSource();
 
@@ -88,10 +87,10 @@ public class PropertyReferencePolicy
 
   @Override
   protected boolean handleIndexMiss(
-      @Nonnull Property property,
-      @Nonnull List<@Nonnull ItemType> itemTypes,
-      @Nonnull String identifier,
-      @Nonnull IReferenceVisitor visitor) {
+      @NonNull Property property,
+      @NonNull List<ItemType> itemTypes,
+      @NonNull String identifier,
+      @NonNull IReferenceVisitor visitor) {
     if (LOGGER.isWarnEnabled()) {
       LOGGER.atWarn().log(
           "property '{}' should reference a {} identified by '{}', but the identifier was not found in the index.",

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
@@ -58,7 +58,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.Index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -71,38 +71,38 @@ import javax.xml.namespace.QName;
 
 public class ReferenceCountingVisitor implements IReferenceVisitor {
   private static final Logger LOGGER = LogManager.getLogger(ReferenceCountingVisitor.class);
-  @NotNull
+  @Nonnull
   private static final MetapathExpression PART_METAPATH
       = MetapathExpression.compile("part|part//part");
-  @NotNull
+  @Nonnull
   private static final MetapathExpression PARAM_MARKUP_METAPATH
       = MetapathExpression
           .compile("label|usage|constraint/(description|tests/remarks)|guideline/prose|select/choice|remarks");
-  @NotNull
+  @Nonnull
   private static final MetapathExpression ROLE_MARKUP_METAPATH
       = MetapathExpression.compile("title|description|remarks");
-  @NotNull
+  @Nonnull
   private static final MetapathExpression LOCATION_MARKUP_METAPATH
       = MetapathExpression.compile("title|remarks");
-  @NotNull
+  @Nonnull
   private static final MetapathExpression PARTY_MARKUP_METAPATH
       = MetapathExpression.compile("title|remarks");
-  @NotNull
+  @Nonnull
   private static final MetapathExpression RESOURCE_MARKUP_METAPATH
       = MetapathExpression.compile("title|description|remarks");
 
-  @NotNull
+  @Nonnull
   private static final IReferencePolicy<Property> PROPERTY_POLICY_IGNORE = IReferencePolicy.ignore();
-  @NotNull
+  @Nonnull
   private static final IReferencePolicy<Link> LINK_POLICY_IGNORE = IReferencePolicy.ignore();
 
-  @NotNull
+  @Nonnull
   private static final Map<QName, IReferencePolicy<Property>> PROPERTY_POLICIES;
-  @NotNull
+  @Nonnull
   private static final Map<String, IReferencePolicy<Link>> LINK_POLICIES;
-  @NotNull
+  @Nonnull
   private static final InsertReferencePolicy INSERT_POLICY = new InsertReferencePolicy();
-  @NotNull
+  @Nonnull
   private static final AnchorReferencePolicy ANCHOR_POLICY = new AnchorReferencePolicy();
 
   static {
@@ -124,29 +124,29 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     LINK_POLICIES.put("required", LinkReferencePolicy.create(ItemType.CONTROL));
   }
 
-  @NotNull
+  @Nonnull
   private final Index index;
-  @NotNull
+  @Nonnull
   private final URI source;
 
-  public ReferenceCountingVisitor(@NotNull Index index, @NotNull URI source) {
+  public ReferenceCountingVisitor(@Nonnull Index index, @Nonnull URI source) {
     this.index = index;
     this.source = source;
   }
 
   @Override
-  @NotNull
+  @Nonnull
   public Index getIndex() {
     return index;
   }
 
-  @NotNull
+  @Nonnull
   protected URI getSource() {
     return source;
   }
 
   //
-  // public void visitProfile(@NotNull Profile profile) {
+  // public void visitProfile(@Nonnull Profile profile) {
   // // process children
   // Metadata metadata = profile.getMetadata();
   // if (metadata != null) {
@@ -161,7 +161,7 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
   // }
   // }
 
-  public void visitCatalog(@NotNull IDocumentNodeItem catalogItem) {
+  public void visitCatalog(@Nonnull IDocumentNodeItem catalogItem) {
 
     // process children
     IRootAssemblyNodeItem rootItem = catalogItem.getRootAssemblyNodeItem();
@@ -190,7 +190,7 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
   }
 
   @Override
-  public void visitRole(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitRole(@Nonnull IRequiredValueModelNodeItem item) {
     Role role = (Role) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.ROLE, ObjectUtils.notNull(role.getId()));
 
@@ -199,12 +199,12 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
 
       item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
       item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      evaluateToList(ROLE_MARKUP_METAPATH, item).forEach(child -> handleMarkup(child));
+      ROLE_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
     }
   }
 
   @Override
-  public void visitParty(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitParty(@Nonnull IRequiredValueModelNodeItem item) {
     Party party = (Party) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.PARTY, ObjectUtils.notNull(party.getUuid()));
 
@@ -213,12 +213,12 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
 
       item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
       item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      evaluateToList(PARTY_MARKUP_METAPATH, item).forEach(child -> handleMarkup(child));
+      PARTY_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
     }
   }
 
   @Override
-  public void visitLocation(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitLocation(@Nonnull IRequiredValueModelNodeItem item) {
     Location location = (Location) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.LOCATION, ObjectUtils.notNull(location.getUuid()));
 
@@ -227,12 +227,12 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
 
       item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
       item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      evaluateToList(LOCATION_MARKUP_METAPATH, item).forEach(child -> handleMarkup(child));
+      LOCATION_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
     }
   }
 
   @Override
-  public void visitResource(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitResource(@Nonnull IRequiredValueModelNodeItem item) {
     Resource resource = (Resource) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.RESOURCE, ObjectUtils.notNull(resource.getUuid()));
 
@@ -247,12 +247,12 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
         child.getModelItemsByName("link").forEach(citationChild -> handleLink(citationChild));
       });
 
-      evaluateToList(RESOURCE_MARKUP_METAPATH, item).forEach(child -> handleMarkup(child));
+      RESOURCE_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
     }
   }
 
   @Override
-  public void visitParameter(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitParameter(@Nonnull IRequiredValueModelNodeItem item) {
     Parameter parameter = (Parameter) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.PARAMETER, ObjectUtils.notNull(parameter.getId()));
 
@@ -261,20 +261,12 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
 
       item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
       item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      evaluateToList(PARAM_MARKUP_METAPATH, item).forEach(child -> handleMarkup(child));
+      PARAM_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
     }
   }
 
-  @NotNull
-  @SuppressWarnings("unchecked")
-  private <T extends INodeItem, R extends IRequiredValueModelNodeItem> List<@NotNull R> evaluateToList(
-      @NotNull MetapathExpression metapath,
-      @NotNull T item) {
-    return ((ISequence<R>) metapath.evaluateAs(item, ResultType.SEQUENCE)).asList();
-  }
-
   @Override
-  public void visitGroup(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitGroup(@Nonnull IRequiredValueModelNodeItem item) {
     CatalogGroup group = (CatalogGroup) item.getValue();
     String id = group.getId();
 
@@ -308,7 +300,7 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
   }
 
   @Override
-  public void visitControl(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitControl(@Nonnull IRequiredValueModelNodeItem item) {
     Control control = (Control) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.CONTROL, ObjectUtils.notNull(control.getId()));
 
@@ -329,16 +321,16 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  protected void visitParts(@NotNull IRequiredValueModelNodeItem groupOrControlItem) {
+  protected void visitParts(@Nonnull IRequiredValueModelNodeItem groupOrControlItem) {
     PART_METAPATH.evaluate(groupOrControlItem).asStream()
-        .map(item -> (@NotNull IRequiredValueModelNodeItem) item)
+        .map(item -> (@Nonnull IRequiredValueModelNodeItem) item)
         .forEachOrdered(partItem -> {
           visitPart(partItem);
         });
   }
 
   @Override
-  public void visitPart(@NotNull IRequiredValueModelNodeItem item) {
+  public void visitPart(@Nonnull IRequiredValueModelNodeItem item) {
     ControlPart part = (ControlPart) item.getValue();
     String id = part.getId();
 
@@ -364,8 +356,8 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @NotNull
-  private void handleMarkup(@NotNull IRequiredValueModelNodeItem item) {
+  @Nonnull
+  private void handleMarkup(@Nonnull IRequiredValueModelNodeItem item) {
     IMarkupItem markupItem = (IMarkupItem) FnData.fnDataItem(item);
     IMarkupText markup = markupItem.getValue();
     if (markup != null) {
@@ -373,8 +365,8 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @NotNull
-  private void handleMarkup(@NotNull IMarkupText text) {
+  @Nonnull
+  private void handleMarkup(@Nonnull IMarkupText text) {
     for (Node node : CollectionUtil.toIterable(text.getNodesAsStream().iterator())) {
       if (node instanceof InsertAnchorNode) {
         handleInsert((InsertAnchorNode) node);
@@ -384,24 +376,24 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @NotNull
-  private void handleInsert(@NotNull InsertAnchorNode node) {
+  @Nonnull
+  private void handleInsert(@Nonnull InsertAnchorNode node) {
     boolean retval = INSERT_POLICY.handleReference(node, this);
     if (LOGGER.isWarnEnabled() && !retval) {
       LOGGER.atWarn().log("unsupported insert type '{}'", node.getType().toString());
     }
   }
 
-  @NotNull
-  private void handleAnchor(@NotNull InlineLinkNode node) {
+  @Nonnull
+  private void handleAnchor(@Nonnull InlineLinkNode node) {
     boolean result = ANCHOR_POLICY.handleReference(node, this);
     if (LOGGER.isWarnEnabled() && !result) {
       LOGGER.atWarn().log("unsupported anchor with href '{}'", node.getUrl().toString());
     }
   }
 
-  @NotNull
-  private void handleProperty(@NotNull IRequiredValueModelNodeItem item) {
+  @Nonnull
+  private void handleProperty(@Nonnull IRequiredValueModelNodeItem item) {
     Property property = (Property) item.getValue();
     QName qname = property.getQName();
 
@@ -413,8 +405,8 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @NotNull
-  private void handleLink(@NotNull IRequiredValueModelNodeItem item) {
+  @Nonnull
+  private void handleLink(@Nonnull IRequiredValueModelNodeItem item) {
     Link link = (Link) item.getValue();
     IReferencePolicy<Link> policy = null;
     String rel = link.getRel();
@@ -429,11 +421,11 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
   }
 
   @SuppressWarnings("null")
-  protected void incrementReferenceCount(@NotNull ItemType type, @NotNull UUID identifier) {
+  protected void incrementReferenceCount(@Nonnull ItemType type, @Nonnull UUID identifier) {
     incrementReferenceCount(type, identifier.toString());
   }
 
-  protected void incrementReferenceCount(@NotNull ItemType type, @NotNull String identifier) {
+  protected void incrementReferenceCount(@Nonnull ItemType type, @Nonnull String identifier) {
     EntityItem item = getIndex().getEntity(type, identifier);
     if (item == null) {
       if (LOGGER.isErrorEnabled()) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
@@ -31,13 +31,10 @@ import com.vladsch.flexmark.util.ast.Node;
 
 import gov.nist.secauto.metaschema.model.common.datatype.markup.IMarkupText;
 import gov.nist.secauto.metaschema.model.common.datatype.markup.flexmark.InsertAnchorNode;
-import gov.nist.secauto.metaschema.model.common.metapath.ISequence;
 import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression;
-import gov.nist.secauto.metaschema.model.common.metapath.MetapathExpression.ResultType;
 import gov.nist.secauto.metaschema.model.common.metapath.function.library.FnData;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IMarkupItem;
-import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRequiredValueModelNodeItem;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IRootAssemblyNodeItem;
 import gov.nist.secauto.metaschema.model.common.util.CollectionUtil;
@@ -52,68 +49,71 @@ import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.Party;
 import gov.nist.secauto.oscal.lib.model.Property;
 import gov.nist.secauto.oscal.lib.model.Role;
+import gov.nist.secauto.oscal.lib.model.metadata.AbstractProperty;
+import gov.nist.secauto.oscal.lib.model.metadata.IProperty;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem;
 import gov.nist.secauto.oscal.lib.profile.resolver.EntityItem.ItemType;
 import gov.nist.secauto.oscal.lib.profile.resolver.Index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
 import javax.xml.namespace.QName;
 
-public class ReferenceCountingVisitor implements IReferenceVisitor {
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class ReferenceCountingVisitor implements IReferenceVisitor { // NOPMD - ok
   private static final Logger LOGGER = LogManager.getLogger(ReferenceCountingVisitor.class);
-  @Nonnull
+  @NonNull
   private static final MetapathExpression PART_METAPATH
       = MetapathExpression.compile("part|part//part");
-  @Nonnull
+  @NonNull
   private static final MetapathExpression PARAM_MARKUP_METAPATH
       = MetapathExpression
           .compile("label|usage|constraint/(description|tests/remarks)|guideline/prose|select/choice|remarks");
-  @Nonnull
+  @NonNull
   private static final MetapathExpression ROLE_MARKUP_METAPATH
       = MetapathExpression.compile("title|description|remarks");
-  @Nonnull
+  @NonNull
   private static final MetapathExpression LOCATION_MARKUP_METAPATH
       = MetapathExpression.compile("title|remarks");
-  @Nonnull
+  @NonNull
   private static final MetapathExpression PARTY_MARKUP_METAPATH
       = MetapathExpression.compile("title|remarks");
-  @Nonnull
+  @NonNull
   private static final MetapathExpression RESOURCE_MARKUP_METAPATH
       = MetapathExpression.compile("title|description|remarks");
 
-  @Nonnull
+  @NonNull
   private static final IReferencePolicy<Property> PROPERTY_POLICY_IGNORE = IReferencePolicy.ignore();
-  @Nonnull
+  @NonNull
   private static final IReferencePolicy<Link> LINK_POLICY_IGNORE = IReferencePolicy.ignore();
 
-  @Nonnull
+  @NonNull
   private static final Map<QName, IReferencePolicy<Property>> PROPERTY_POLICIES;
-  @Nonnull
+  @NonNull
   private static final Map<String, IReferencePolicy<Link>> LINK_POLICIES;
-  @Nonnull
+  @NonNull
   private static final InsertReferencePolicy INSERT_POLICY = new InsertReferencePolicy();
-  @Nonnull
+  @NonNull
   private static final AnchorReferencePolicy ANCHOR_POLICY = new AnchorReferencePolicy();
 
   static {
     PROPERTY_POLICIES = new HashMap<>();
-    PROPERTY_POLICIES.put(Property.qname(Property.OSCAL_NAMESPACE, "resolution-tool"), PROPERTY_POLICY_IGNORE);
-    PROPERTY_POLICIES.put(Property.qname(Property.OSCAL_NAMESPACE, "label"), PROPERTY_POLICY_IGNORE);
-    PROPERTY_POLICIES.put(Property.qname(Property.OSCAL_NAMESPACE, "sort-id"), PROPERTY_POLICY_IGNORE);
-    PROPERTY_POLICIES.put(Property.qname(Property.OSCAL_NAMESPACE, "alt-label"), PROPERTY_POLICY_IGNORE);
-    PROPERTY_POLICIES.put(Property.qname(Property.OSCAL_NAMESPACE, "alt-identifier"), PROPERTY_POLICY_IGNORE);
-    PROPERTY_POLICIES.put(Property.qname(Property.RMF_NAMESPACE, "method"), PROPERTY_POLICY_IGNORE);
-    PROPERTY_POLICIES.put(Property.qname(Property.RMF_NAMESPACE, "aggregates"),
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.OSCAL_NAMESPACE, "resolution-tool"), PROPERTY_POLICY_IGNORE);
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.OSCAL_NAMESPACE, "label"), PROPERTY_POLICY_IGNORE);
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.OSCAL_NAMESPACE, "sort-id"), PROPERTY_POLICY_IGNORE);
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.OSCAL_NAMESPACE, "alt-label"), PROPERTY_POLICY_IGNORE);
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.OSCAL_NAMESPACE, "alt-identifier"), PROPERTY_POLICY_IGNORE);
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.RMF_NAMESPACE, "method"), PROPERTY_POLICY_IGNORE);
+    PROPERTY_POLICIES.put(AbstractProperty.qname(IProperty.RMF_NAMESPACE, "aggregates"),
         PropertyReferencePolicy.create(IIdentifierParser.IDENTITY_PARSER, ItemType.PARAMETER));
 
     LINK_POLICIES = new HashMap<>();
@@ -124,29 +124,31 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     LINK_POLICIES.put("required", LinkReferencePolicy.create(ItemType.CONTROL));
   }
 
-  @Nonnull
+  @NonNull
   private final Index index;
-  @Nonnull
+  @NonNull
   private final URI source;
 
-  public ReferenceCountingVisitor(@Nonnull Index index, @Nonnull URI source) {
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intending to store this parameter")
+  public ReferenceCountingVisitor(@NonNull Index index, @NonNull URI source) {
     this.index = index;
     this.source = source;
   }
 
   @Override
-  @Nonnull
+  @NonNull
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intending to expose this field")
   public Index getIndex() {
     return index;
   }
 
-  @Nonnull
+  @NonNull
   protected URI getSource() {
     return source;
   }
 
   //
-  // public void visitProfile(@Nonnull Profile profile) {
+  // public void visitProfile(@NonNull Profile profile) {
   // // process children
   // Metadata metadata = profile.getMetadata();
   // if (metadata != null) {
@@ -161,26 +163,26 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
   // }
   // }
 
-  public void visitCatalog(@Nonnull IDocumentNodeItem catalogItem) {
+  public void visitCatalog(@NonNull IDocumentNodeItem catalogItem) {
 
     // process children
     IRootAssemblyNodeItem rootItem = catalogItem.getRootAssemblyNodeItem();
 
     rootItem.getModelItemsByName("group").forEach(groupItem -> {
-      visitGroup(groupItem);
+      visitGroup(ObjectUtils.notNull(groupItem));
     });
 
     rootItem.getModelItemsByName("control").forEach(controlItem -> {
-      visitControl(controlItem);
+      visitControl(ObjectUtils.notNull(controlItem));
     });
-    index.getEntitiesByItemType(ItemType.ROLE).forEach(item -> resolveItem(item));
-    index.getEntitiesByItemType(ItemType.LOCATION).forEach(item -> resolveItem(item));
-    index.getEntitiesByItemType(ItemType.PARTY).forEach(item -> resolveItem(item));
-    index.getEntitiesByItemType(ItemType.PARAMETER).forEach(item -> resolveItem(item));
-    index.getEntitiesByItemType(ItemType.RESOURCE).forEach(item -> resolveItem(item));
+    index.getEntitiesByItemType(ItemType.ROLE).forEach(item -> resolveItem(ObjectUtils.notNull(item)));
+    index.getEntitiesByItemType(ItemType.LOCATION).forEach(item -> resolveItem(ObjectUtils.notNull(item)));
+    index.getEntitiesByItemType(ItemType.PARTY).forEach(item -> resolveItem(ObjectUtils.notNull(item)));
+    index.getEntitiesByItemType(ItemType.PARAMETER).forEach(item -> resolveItem(ObjectUtils.notNull(item)));
+    index.getEntitiesByItemType(ItemType.RESOURCE).forEach(item -> resolveItem(ObjectUtils.notNull(item)));
   }
 
-  private void resolveItem(EntityItem item) {
+  private void resolveItem(@NonNull EntityItem item) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("Resolving {} identified as '{}'", item.getItemType().name(), item.getIdentifier());
     }
@@ -190,83 +192,91 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
   }
 
   @Override
-  public void visitRole(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitRole(@NonNull IRequiredValueModelNodeItem item) {
     Role role = (Role) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.ROLE, ObjectUtils.notNull(role.getId()));
 
     if (!entity.isResolved()) {
       entity.markResolved();
 
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-      item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      ROLE_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
+      ROLE_MARKUP_METAPATH.evaluate(item).asList()
+          .forEach(child -> handleMarkup(ObjectUtils.notNull((IRequiredValueModelNodeItem) child)));
     }
   }
 
   @Override
-  public void visitParty(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitParty(@NonNull IRequiredValueModelNodeItem item) {
     Party party = (Party) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.PARTY, ObjectUtils.notNull(party.getUuid()));
 
     if (!entity.isResolved()) {
       entity.markResolved();
 
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-      item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      PARTY_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
+      PARTY_MARKUP_METAPATH.evaluate(item).asList()
+          .forEach(child -> handleMarkup(ObjectUtils.notNull((IRequiredValueModelNodeItem) child)));
     }
   }
 
   @Override
-  public void visitLocation(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitLocation(@NonNull IRequiredValueModelNodeItem item) {
     Location location = (Location) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.LOCATION, ObjectUtils.notNull(location.getUuid()));
 
     if (!entity.isResolved()) {
       entity.markResolved();
 
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-      item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      LOCATION_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
+      LOCATION_MARKUP_METAPATH.evaluate(item).asList()
+          .forEach(child -> handleMarkup(ObjectUtils.notNull((IRequiredValueModelNodeItem) child)));
     }
   }
 
   @Override
-  public void visitResource(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitResource(@NonNull IRequiredValueModelNodeItem item) {
     Resource resource = (Resource) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.RESOURCE, ObjectUtils.notNull(resource.getUuid()));
 
     if (!entity.isResolved()) {
       entity.markResolved();
 
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
 
       item.getModelItemsByName("citation").forEach(child -> {
-        child.getModelItemsByName("text").forEach(citationChild -> handleMarkup(citationChild));
-        child.getModelItemsByName("prop").forEach(citationChild -> handleProperty(citationChild));
-        child.getModelItemsByName("link").forEach(citationChild -> handleLink(citationChild));
+        if (child != null) {
+          child.getModelItemsByName("text").forEach(citationChild -> handleMarkup(ObjectUtils.notNull(citationChild)));
+          child.getModelItemsByName("prop")
+              .forEach(citationChild -> handleProperty(ObjectUtils.notNull(citationChild)));
+          child.getModelItemsByName("link").forEach(citationChild -> handleLink(ObjectUtils.notNull(citationChild)));
+        }
       });
 
-      RESOURCE_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
+      RESOURCE_MARKUP_METAPATH.evaluate(item).asList()
+          .forEach(child -> handleMarkup(ObjectUtils.notNull((IRequiredValueModelNodeItem) child)));
     }
   }
 
   @Override
-  public void visitParameter(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitParameter(@NonNull IRequiredValueModelNodeItem item) {
     Parameter parameter = (Parameter) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.PARAMETER, ObjectUtils.notNull(parameter.getId()));
 
     if (!entity.isResolved()) {
       entity.markResolved();
 
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-      item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      PARAM_MARKUP_METAPATH.evaluate(item).asList().forEach(child -> handleMarkup((IRequiredValueModelNodeItem)child));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
+      PARAM_MARKUP_METAPATH.evaluate(item).asList()
+          .forEach(child -> handleMarkup(ObjectUtils.notNull((IRequiredValueModelNodeItem) child)));
     }
   }
 
   @Override
-  public void visitGroup(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitGroup(@NonNull IRequiredValueModelNodeItem item) {
     CatalogGroup group = (CatalogGroup) item.getValue();
     String id = group.getId();
 
@@ -285,22 +295,22 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
 
     if (resolve && getIndex().isSelected(group)) {
       // process children
-      item.getModelItemsByName("title").forEach(child -> handleMarkup(child));
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-      item.getModelItemsByName("link").forEach(child -> handleLink(child));
+      item.getModelItemsByName("title").forEach(child -> handleMarkup(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
       visitParts(item);
 
       // only process these if the current group is selected, since the group will only be selected if a
       // child is selected
-      item.getModelItemsByName("group").forEach(child -> visitGroup(child));
-      item.getModelItemsByName("control").forEach(child -> visitControl(child));
+      item.getModelItemsByName("group").forEach(child -> visitGroup(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("control").forEach(child -> visitControl(ObjectUtils.notNull(child)));
 
       // skip parameters for now. These will be processed by a separate pass.
     }
   }
 
   @Override
-  public void visitControl(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitControl(@NonNull IRequiredValueModelNodeItem item) {
     Control control = (Control) item.getValue();
     EntityItem entity = getIndex().getEntity(ItemType.CONTROL, ObjectUtils.notNull(control.getId()));
 
@@ -308,29 +318,29 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
       entity.markResolved();
       if (getIndex().isSelected(control)) {
         // process non-control, non-param children
-        item.getModelItemsByName("title").forEach(child -> handleMarkup(child));
-        item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-        item.getModelItemsByName("link").forEach(child -> handleLink(child));
+        item.getModelItemsByName("title").forEach(child -> handleMarkup(ObjectUtils.notNull(child)));
+        item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+        item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
         visitParts(item);
 
         // skip parameters for now. These will be processed by a separate pass.
       }
 
       // Always process these, since we don't know if the child control is selected
-      item.getModelItemsByName("control").forEach(child -> visitControl(child));
+      item.getModelItemsByName("control").forEach(child -> visitControl(ObjectUtils.notNull(child)));
     }
   }
 
-  protected void visitParts(@Nonnull IRequiredValueModelNodeItem groupOrControlItem) {
+  protected void visitParts(@NonNull IRequiredValueModelNodeItem groupOrControlItem) {
     PART_METAPATH.evaluate(groupOrControlItem).asStream()
-        .map(item -> (@Nonnull IRequiredValueModelNodeItem) item)
+        .map(item -> (IRequiredValueModelNodeItem) item)
         .forEachOrdered(partItem -> {
-          visitPart(partItem);
+          visitPart(ObjectUtils.notNull(partItem));
         });
   }
 
   @Override
-  public void visitPart(@Nonnull IRequiredValueModelNodeItem item) {
+  public void visitPart(@NonNull IRequiredValueModelNodeItem item) {
     ControlPart part = (ControlPart) item.getValue();
     String id = part.getId();
 
@@ -348,25 +358,21 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
 
     if (resolve) {
-      item.getModelItemsByName("title").forEach(child -> handleMarkup(child));
-      item.getModelItemsByName("prop").forEach(child -> handleProperty(child));
-      item.getModelItemsByName("link").forEach(child -> handleLink(child));
-      item.getModelItemsByName("prose").forEach(child -> handleMarkup(child));
-      item.getModelItemsByName("part").forEach(child -> visitParts(child));
+      item.getModelItemsByName("title").forEach(child -> handleMarkup(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("prose").forEach(child -> handleMarkup(ObjectUtils.notNull(child)));
+      item.getModelItemsByName("part").forEach(child -> visitParts(ObjectUtils.notNull(child)));
     }
   }
 
-  @Nonnull
-  private void handleMarkup(@Nonnull IRequiredValueModelNodeItem item) {
+  private void handleMarkup(@NonNull IRequiredValueModelNodeItem item) {
     IMarkupItem markupItem = (IMarkupItem) FnData.fnDataItem(item);
     IMarkupText markup = markupItem.getValue();
-    if (markup != null) {
-      handleMarkup(markup);
-    }
+    handleMarkup(markup);
   }
 
-  @Nonnull
-  private void handleMarkup(@Nonnull IMarkupText text) {
+  private void handleMarkup(@NonNull IMarkupText text) {
     for (Node node : CollectionUtil.toIterable(text.getNodesAsStream().iterator())) {
       if (node instanceof InsertAnchorNode) {
         handleInsert((InsertAnchorNode) node);
@@ -376,24 +382,21 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @Nonnull
-  private void handleInsert(@Nonnull InsertAnchorNode node) {
+  private void handleInsert(@NonNull InsertAnchorNode node) {
     boolean retval = INSERT_POLICY.handleReference(node, this);
     if (LOGGER.isWarnEnabled() && !retval) {
       LOGGER.atWarn().log("unsupported insert type '{}'", node.getType().toString());
     }
   }
 
-  @Nonnull
-  private void handleAnchor(@Nonnull InlineLinkNode node) {
+  private void handleAnchor(@NonNull InlineLinkNode node) {
     boolean result = ANCHOR_POLICY.handleReference(node, this);
     if (LOGGER.isWarnEnabled() && !result) {
       LOGGER.atWarn().log("unsupported anchor with href '{}'", node.getUrl().toString());
     }
   }
 
-  @Nonnull
-  private void handleProperty(@Nonnull IRequiredValueModelNodeItem item) {
+  private void handleProperty(@NonNull IRequiredValueModelNodeItem item) {
     Property property = (Property) item.getValue();
     QName qname = property.getQName();
 
@@ -405,8 +408,7 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @Nonnull
-  private void handleLink(@Nonnull IRequiredValueModelNodeItem item) {
+  private void handleLink(@NonNull IRequiredValueModelNodeItem item) {
     Link link = (Link) item.getValue();
     IReferencePolicy<Link> policy = null;
     String rel = link.getRel();
@@ -420,12 +422,11 @@ public class ReferenceCountingVisitor implements IReferenceVisitor {
     }
   }
 
-  @SuppressWarnings("null")
-  protected void incrementReferenceCount(@Nonnull ItemType type, @Nonnull UUID identifier) {
-    incrementReferenceCount(type, identifier.toString());
+  protected void incrementReferenceCount(@NonNull ItemType type, @NonNull UUID identifier) {
+    incrementReferenceCount(type, ObjectUtils.notNull(identifier.toString()));
   }
 
-  protected void incrementReferenceCount(@Nonnull ItemType type, @Nonnull String identifier) {
+  protected void incrementReferenceCount(@NonNull ItemType type, @NonNull String identifier) {
     EntityItem item = getIndex().getEntity(type, identifier);
     if (item == null) {
       if (LOGGER.isErrorEnabled()) {

--- a/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
+++ b/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
@@ -31,6 +31,14 @@
 		</define-assembly-binding>
 	</metaschema-binding>
 	<metaschema-binding
+		href="../../../oscal/src/metaschema/oscal_mapping-common_metaschema.xml">
+		<define-assembly-binding name="map">
+			<java>
+				<use-class-name>MappingEntry</use-class-name>
+			</java>
+		</define-assembly-binding>
+	</metaschema-binding>
+	<metaschema-binding
 		href="../../../oscal/src/metaschema/oscal_control-common_metaschema.xml">
 		<define-assembly-binding name="parameter">
 			<java>

--- a/src/main/resources/META-INF/services/gov.nist.secauto.metaschema.model.common.metapath.function.IFunctionLibrary
+++ b/src/main/resources/META-INF/services/gov.nist.secauto.metaschema.model.common.metapath.function.IFunctionLibrary
@@ -1,1 +1,0 @@
-gov.nist.secauto.oscal.lib.metapath.function.library.OscalFunctionLibrary

--- a/src/test/java/gov/nist/secauto/oscal/java/ExamplesTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/ExamplesTest.java
@@ -26,15 +26,27 @@
 
 package gov.nist.secauto.oscal.java;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.binding.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.binding.io.IBoundLoader;
 import gov.nist.secauto.metaschema.binding.io.ISerializer;
+import gov.nist.secauto.metaschema.model.common.constraint.DefaultConstraintValidator;
+import gov.nist.secauto.metaschema.model.common.constraint.FindingCollectingConstraintValidationHandler;
+import gov.nist.secauto.metaschema.model.common.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.model.common.metapath.StaticContext;
+import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import gov.nist.secauto.oscal.lib.model.Catalog;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,4 +72,34 @@ class ExamplesTest {
     // serialize the catalog as yaml
     serializer.serialize(catalog, outDir.resolve("test-catalog.yaml"));
   }
+
+  @Test
+  void testConstraintValidation() throws MalformedURLException, IOException, URISyntaxException {
+    // Initialize the Metaschema framework
+    OscalBindingContext bindingContext = OscalBindingContext.instance(); // manages the Metaschema model
+    IBoundLoader loader = bindingContext.newBoundLoader(); // supports loading OSCAL documents
+    loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
+
+    IDocumentNodeItem nodeItem = loader.loadAsNodeItem(new URL(
+        "https://raw.githubusercontent.com/Rene2mt/fedramp-automation/a692b9385d8fbcacbb1d3e3d0b0d7e3c45a205d0/src/content/baselines/rev5/xml/FedRAMP_rev5_HIGH-baseline_profile.xml"));
+
+    DynamicContext dynamicContext = new StaticContext().newDynamicContext();
+    dynamicContext.setDocumentLoader(loader);
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(dynamicContext, handler);
+
+    validator.validate(nodeItem);
+    validator.finalizeValidation();
+
+    assertTrue(handler.isPassing());
+
+    IDocumentNodeItem resolvedCatalog = new ProfileResolver().resolve(nodeItem);
+    
+
+    // Create a serializer which can be used to write multiple catalogs
+    ISerializer<Catalog> serializer = bindingContext.newSerializer(Format.YAML, Catalog.class);
+    // serialize the catalog as yaml
+    serializer.serialize((Catalog)resolvedCatalog.getValue(), System.out);
+  }
+
 }

--- a/src/test/java/gov/nist/secauto/oscal/java/ExamplesTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/ExamplesTest.java
@@ -39,6 +39,7 @@ import gov.nist.secauto.metaschema.model.common.metapath.StaticContext;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import gov.nist.secauto.oscal.lib.model.Catalog;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionException;
 import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver;
 
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,7 @@ class ExamplesTest {
   }
 
   @Test
-  void testConstraintValidation() throws MalformedURLException, IOException, URISyntaxException {
+  void testConstraintValidation() throws MalformedURLException, IOException, URISyntaxException, ProfileResolutionException {
     // Initialize the Metaschema framework
     OscalBindingContext bindingContext = OscalBindingContext.instance(); // manages the Metaschema model
     IBoundLoader loader = bindingContext.newBoundLoader(); // supports loading OSCAL documents
@@ -94,12 +95,10 @@ class ExamplesTest {
     assertTrue(handler.isPassing());
 
     IDocumentNodeItem resolvedCatalog = new ProfileResolver().resolve(nodeItem);
-    
 
     // Create a serializer which can be used to write multiple catalogs
     ISerializer<Catalog> serializer = bindingContext.newSerializer(Format.YAML, Catalog.class);
     // serialize the catalog as yaml
-    serializer.serialize((Catalog)resolvedCatalog.getValue(), System.out);
+    serializer.serialize((Catalog) resolvedCatalog.getValue(), System.out);
   }
-
 }

--- a/src/test/java/gov/nist/secauto/oscal/java/MetaschemaVisitorTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/MetaschemaVisitorTest.java
@@ -37,7 +37,7 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import gov.nist.secauto.oscal.lib.metapath.function.library.ResolveProfile;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -57,7 +57,7 @@ class MetaschemaVisitorTest {
 
     StaticContext staticContext = new StaticContext();
     @SuppressWarnings("null")
-    @Nonnull
+    @NonNull
     URI baseUri = new File("").getAbsoluteFile().toURI();
     staticContext.setBaseUri(baseUri);
     DynamicContext dynamicContext = staticContext.newDynamicContext();
@@ -70,7 +70,7 @@ class MetaschemaVisitorTest {
     IDocumentNodeItem nodeItem = loader.loadAsNodeItem(new URL(
         "https://raw.githubusercontent.com/usnistgov/oscal-content/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_HIGH-baseline_profile.xml"));
 
-    // @Nonnull
+    // @NonNull
     // Profile profile = nodeItem.toBoundObject();
 
     IDocumentNodeItem resolvedProfile = ResolveProfile.resolveProfile(nodeItem, dynamicContext);
@@ -110,8 +110,8 @@ class MetaschemaVisitorTest {
   }
 
   @SuppressWarnings("PMD")
-  private void evaluatePath(@Nonnull MetapathExpression path, @Nonnull INodeContext nodeContext,
-      @Nonnull DynamicContext dynamicContext) {
+  private void evaluatePath(@NonNull MetapathExpression path, @NonNull INodeContext nodeContext,
+      @NonNull DynamicContext dynamicContext) {
     System.out.println("Path: " + path.getPath());
     System.out.println("Compiled Path: " + path.toString());
 

--- a/src/test/java/gov/nist/secauto/oscal/java/MetaschemaVisitorTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/MetaschemaVisitorTest.java
@@ -37,7 +37,7 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import gov.nist.secauto.oscal.lib.metapath.function.library.ResolveProfile;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -57,7 +57,7 @@ class MetaschemaVisitorTest {
 
     StaticContext staticContext = new StaticContext();
     @SuppressWarnings("null")
-    @NotNull
+    @Nonnull
     URI baseUri = new File("").getAbsoluteFile().toURI();
     staticContext.setBaseUri(baseUri);
     DynamicContext dynamicContext = staticContext.newDynamicContext();
@@ -70,7 +70,7 @@ class MetaschemaVisitorTest {
     IDocumentNodeItem nodeItem = loader.loadAsNodeItem(new URL(
         "https://raw.githubusercontent.com/usnistgov/oscal-content/master/nist.gov/SP800-53/rev5/xml/NIST_SP-800-53_rev5_HIGH-baseline_profile.xml"));
 
-    // @NotNull
+    // @Nonnull
     // Profile profile = nodeItem.toBoundObject();
 
     IDocumentNodeItem resolvedProfile = ResolveProfile.resolveProfile(nodeItem, dynamicContext);
@@ -110,8 +110,8 @@ class MetaschemaVisitorTest {
   }
 
   @SuppressWarnings("PMD")
-  private void evaluatePath(@NotNull MetapathExpression path, @NotNull INodeContext nodeContext,
-      @NotNull DynamicContext dynamicContext) {
+  private void evaluatePath(@Nonnull MetapathExpression path, @Nonnull INodeContext nodeContext,
+      @Nonnull DynamicContext dynamicContext) {
     System.out.println("Path: " + path.getPath());
     System.out.println("Compiled Path: " + path.toString());
 

--- a/src/test/java/gov/nist/secauto/oscal/java/OscalBindingContextTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/OscalBindingContextTest.java
@@ -38,7 +38,7 @@ import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.model.Profile;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -136,7 +136,7 @@ class OscalBindingContextTest {
     // out.delete();
   }
 
-  static Path newPath(@NotNull Path dir, @NotNull String filename) {
+  static Path newPath(@Nonnull Path dir, @Nonnull String filename) {
     return dir.resolve(filename);
     // return Path.of("target",filename);
   }

--- a/src/test/java/gov/nist/secauto/oscal/java/OscalBindingContextTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/OscalBindingContextTest.java
@@ -38,7 +38,7 @@ import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.model.Profile;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -136,7 +136,7 @@ class OscalBindingContextTest {
     // out.delete();
   }
 
-  static Path newPath(@Nonnull Path dir, @Nonnull String filename) {
+  static Path newPath(@NonNull Path dir, @NonNull String filename) {
     return dir.resolve(filename);
     // return Path.of("target",filename);
   }
@@ -159,7 +159,11 @@ class OscalBindingContextTest {
 
     // File out = new File(tempDir.toFile(), "out.xml");
     Path out = Paths.get("target/generated-test-resources/catalog-with-lists.xml");
-    Files.createDirectories(out.getParent());
+
+    Path parent = out.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
     IBindingContext context = IBindingContext.instance();
 
     ISerializer<Catalog> serializer = context.newSerializer(Format.XML, Catalog.class);

--- a/src/test/java/gov/nist/secauto/oscal/java/ReadWriteTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/ReadWriteTest.java
@@ -144,7 +144,6 @@ class ReadWriteTest {
     // outDir.mkdirs();
     // Path outPath = outDir.toPath();
     Path outPath = tempDir;
-     chainReadWrite(catalogSourceXml, Catalog.class, tempDir, 10);
-//    chainReadWrite(catalogSourceXml, Catalog.class, outPath, 1);
+    chainReadWrite(catalogSourceXml, Catalog.class, outPath, 1);
   }
 }

--- a/src/test/java/gov/nist/secauto/oscal/java/ReadWriteTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/ReadWriteTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.BindingException;
+import gov.nist.secauto.metaschema.binding.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.binding.io.IDeserializer;
 import gov.nist.secauto.metaschema.binding.io.ISerializer;
@@ -99,6 +100,7 @@ class ReadWriteTest {
     // XML
     {
       IDeserializer<CLASS> deserializer = context.newDeserializer(Format.XML, clazz);
+      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
       obj = measureDeserializer("XML", xmlSource, deserializer, iterations);
 
       File out = new File(tempDir.toFile(), "out.xml");
@@ -113,6 +115,7 @@ class ReadWriteTest {
       measureSerializer(obj, "JSON", out, serializer, iterations);
 
       IDeserializer<CLASS> deserializer = context.newDeserializer(Format.JSON, clazz);
+      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
       obj = measureDeserializer("JSON", out, deserializer, iterations);
     }
 
@@ -123,6 +126,7 @@ class ReadWriteTest {
       measureSerializer(obj, "YAML", out, serializer, iterations);
 
       IDeserializer<CLASS> deserializer = context.newDeserializer(Format.YAML, clazz);
+      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
       measureDeserializer("YAML", out, deserializer, iterations);
     }
   }
@@ -140,7 +144,7 @@ class ReadWriteTest {
     // outDir.mkdirs();
     // Path outPath = outDir.toPath();
     Path outPath = tempDir;
-    // chainReadWrite(catalogSourceXml, Catalog.class, tempDir, 50);
-    chainReadWrite(catalogSourceXml, Catalog.class, outPath, 1);
+     chainReadWrite(catalogSourceXml, Catalog.class, tempDir, 10);
+//    chainReadWrite(catalogSourceXml, Catalog.class, outPath, 1);
   }
 }

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilterTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilterTest.java
@@ -33,7 +33,7 @@ import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControl;
 import gov.nist.secauto.oscal.lib.model.control.profile.IProfileSelectControlById;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.jmock.Expectations;
 import org.jmock.auto.Mock;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
@@ -159,7 +159,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newEmptyFilter();
-    Pair<@NotNull Boolean, @NotNull Boolean> pair = filter.apply(control1);
+    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
   }
@@ -183,7 +183,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newSingleSelectionFilter();
-    Pair<@NotNull Boolean, @NotNull Boolean> pair = filter.apply(control1);
+    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
 
@@ -211,7 +211,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newSingleSelectionWithChildFilter();
-    Pair<@NotNull Boolean, @NotNull Boolean> pair = filter.apply(control1);
+    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
 
@@ -259,7 +259,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newMultipleSelectionFilter();
-    Pair<@NotNull Boolean, @NotNull Boolean> pair = filter.apply(control1);
+    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
 

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilterTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/DefaultControlSelectionFilterTest.java
@@ -32,8 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById;
 import gov.nist.secauto.oscal.lib.model.control.catalog.IControl;
 import gov.nist.secauto.oscal.lib.model.control.profile.IProfileSelectControlById;
+
 import org.apache.commons.lang3.tuple.Pair;
-import javax.annotation.Nonnull;
 import org.jmock.Expectations;
 import org.jmock.auto.Mock;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
@@ -44,6 +44,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.Collections;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 class DefaultControlSelectionFilterTest {
   @RegisterExtension
   final JUnit5Mockery context = new JUnit5Mockery() {
@@ -53,15 +55,15 @@ class DefaultControlSelectionFilterTest {
   };
 
   @Mock
-  private IProfileSelectControlById selectControlByIdA;
+  private IProfileSelectControlById selectControlByIdA; // NOPMD - injected
   @Mock
-  private ProfileSelectControlById.Matching matchingA;
+  private ProfileSelectControlById.Matching matchingA; // NOPMD - injected
   @Mock
-  private ProfileSelectControlById.Matching matchingB;
+  private ProfileSelectControlById.Matching matchingB; // NOPMD - injected
   @Mock
-  private IProfileSelectControlById selectControlByIdB;
+  private IProfileSelectControlById selectControlByIdB; // NOPMD - injected
 
-  @SuppressWarnings("null")
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   private IControlSelectionFilter newEmptyFilter() {
     context.checking(new Expectations() {
       { // NOPMD - intentional
@@ -77,7 +79,7 @@ class DefaultControlSelectionFilterTest {
     return new DefaultControlSelectionFilter(List.of(selectControlByIdA));
   }
 
-  @SuppressWarnings("null")
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   private IControlSelectionFilter newSingleSelectionFilter() {
     final List<String> withIds = List.of("test1", "test2");
     context.checking(new Expectations() {
@@ -96,7 +98,7 @@ class DefaultControlSelectionFilterTest {
     return new DefaultControlSelectionFilter(List.of(selectControlByIdA));
   }
 
-  @SuppressWarnings("null")
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   private IControlSelectionFilter newSingleSelectionWithChildFilter() {
     final List<String> withIds = List.of("test1", "test2");
     context.checking(new Expectations() {
@@ -115,7 +117,7 @@ class DefaultControlSelectionFilterTest {
     return new DefaultControlSelectionFilter(List.of(selectControlByIdA));
   }
 
-  @SuppressWarnings("null")
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   private IControlSelectionFilter newMultipleSelectionFilter() {
     final List<String> withIdsA = List.of("test1", "test2", "example1");
     final List<String> withIdsB = List.of("test3", "test4");
@@ -148,6 +150,7 @@ class DefaultControlSelectionFilterTest {
    * Test the filtering of an empty set of match criteria
    */
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   void testEmpty() {
     @SuppressWarnings("null")
     final IControl control1 = context.mock(IControl.class);
@@ -159,7 +162,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newEmptyFilter();
-    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
+    Pair<Boolean, Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
   }
@@ -168,6 +171,7 @@ class DefaultControlSelectionFilterTest {
    * Test the filtering of a single match criteria using "with-ids".
    */
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   void testSingleSelectionWithIdsFilter() {
     @SuppressWarnings("null")
     final IControl control1 = context.mock(IControl.class, "control1");
@@ -183,7 +187,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newSingleSelectionFilter();
-    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
+    Pair<Boolean, Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
 
@@ -196,6 +200,7 @@ class DefaultControlSelectionFilterTest {
    * Test the filtering of a single match criteria using "with-ids" and "with-child=yes".
    */
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   void testSingleSelectionWithIdsWithChildFilter() {
     @SuppressWarnings("null")
     final IControl control1 = context.mock(IControl.class, "control1");
@@ -211,7 +216,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newSingleSelectionWithChildFilter();
-    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
+    Pair<Boolean, Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
 
@@ -224,6 +229,7 @@ class DefaultControlSelectionFilterTest {
    * Test the filtering of multiple match criteria.
    */
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   void testMultipleSelectionFilter() {
     @SuppressWarnings("null")
     final IControl control1 = context.mock(IControl.class, "control1");
@@ -259,7 +265,7 @@ class DefaultControlSelectionFilterTest {
     });
 
     IControlSelectionFilter filter = newMultipleSelectionFilter();
-    Pair<@Nonnull Boolean, @Nonnull Boolean> pair = filter.apply(control1);
+    Pair<Boolean, Boolean> pair = filter.apply(control1);
     assertFalse(pair.getLeft());
     assertFalse(pair.getRight());
 

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ImportTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ImportTest.java
@@ -42,7 +42,7 @@ import gov.nist.secauto.oscal.lib.model.Profile;
 import gov.nist.secauto.oscal.lib.model.ProfileImport;
 import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -51,7 +51,7 @@ import java.util.Collections;
 
 class ImportTest {
 
-  @NotNull
+  @Nonnull
   private IDocumentNodeItem newImportedCatalog() {
 
     // setup the imported catalog

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ModifyPhaseUtilsTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ModifyPhaseUtilsTest.java
@@ -24,36 +24,78 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.oscal.lib.profile.resolver.policy;
+package gov.nist.secauto.oscal.lib.profile.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
-public interface ICustomReferencePolicy<TYPE> extends IReferencePolicy<TYPE> {
+class ModifyPhaseUtilsTest {
 
-  /**
-   * Get the parser to use to parse an entity identifier from the reference text.
-   * 
-   * @return the parser
-   */
-  @NonNull
-  IIdentifierParser getIdentifierParser();
+  @Test
+  void testMergeOrdering() {
+    List<TestItem> originalItems = List.of(
+        item("A"),
+        item("id1", "B"),
+        item("C"));
 
-  /**
-   * Retrieve the reference text from the {@code reference} object.
-   * 
-   * @param reference
-   *          the reference object
-   * @return the reference text or {@code null} if there is no text
-   */
-  String getReferenceText(@NonNull TYPE reference);
+    List<TestItem> newItems = List.of(
+        item("D"),
+        item("id1", "E"),
+        item("F"));
 
-  /**
-   * Update the reference text used in the {@code reference} object.
-   * 
-   * @param reference
-   *          the reference object
-   * @param newReferenceText
-   *          the reference text replacement
-   */
-  void setReferenceText(@NonNull TYPE reference, @NonNull String newReferenceText);
+    List<TestItem> result
+        = ModifyPhaseUtils.merge(originalItems, newItems, ModifyPhaseUtils.identifierKey(TestItem::getIdentifier));
+
+    assertEquals(
+        List.of("A", "C", "D", "E", "F"),
+        result.stream()
+            .map(item -> item.getValue())
+            .collect(Collectors.toList()));
+  }
+
+  private TestItem item(@NonNull String value) {
+    return item(null, value);
+  }
+
+  private TestItem item(@Nullable String identifier, @NonNull String value) {
+    return new TestItem(identifier, value);
+  }
+
+  private static class TestItem {
+    @Nullable
+    private final String identifier;
+    @NonNull
+    private final String value;
+
+    private TestItem(@Nullable String identifier, @NonNull String value) {
+      this.identifier = identifier;
+      this.value = value;
+    }
+
+    public String getIdentifier() {
+      return identifier;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return new StringBuffer()
+          .append('[')
+          .append(getIdentifier())
+          .append(',')
+          .append(getValue())
+          .append(']')
+          .toString();
+    }
+  }
 }

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
@@ -48,7 +48,7 @@ import net.sf.saxon.s9api.XsltTransformer;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -102,12 +102,12 @@ class ProfileResolutionTests {
     return profileResolver;
   }
 
-  private Catalog resolveProfile(@NotNull Path profileFile)
+  private Catalog resolveProfile(@Nonnull Path profileFile)
       throws FileNotFoundException, BindingException, IOException {
     return (Catalog) getProfileResolver().resolveProfile(profileFile).getValue();
   }
 
-  private Catalog resolveProfile(@NotNull File profileFile)
+  private Catalog resolveProfile(@Nonnull File profileFile)
       throws FileNotFoundException, BindingException, IOException {
     return (Catalog) getProfileResolver().resolveProfile(profileFile).getValue();
   }
@@ -152,7 +152,7 @@ class ProfileResolutionTests {
     Assertions.assertThat(catalog.getMetadata().getProps()).filteredOn("name", "resolution-tool").extracting("value")
         .hasSize(1);
 
-    ISerializer<@NotNull Catalog> serializer = OscalBindingContext.instance().newSerializer(Format.XML, Catalog.class);
+    ISerializer<@Nonnull Catalog> serializer = OscalBindingContext.instance().newSerializer(Format.XML, Catalog.class);
     StringWriter writer = new StringWriter();
     serializer.serialize(catalog, writer);
 

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import gov.nist.secauto.metaschema.binding.io.BindingException;
 import gov.nist.secauto.metaschema.binding.io.DefaultBoundLoader;
 import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.binding.io.ISerializer;
@@ -48,7 +47,6 @@ import net.sf.saxon.s9api.XsltTransformer;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import javax.annotation.Nonnull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,6 +64,8 @@ import java.time.ZoneOffset;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 class ProfileResolutionTests {
   private static final String XSLT_PATH = "oscal/src/utils/util/resolver-pipeline/oscal-profile-test-helper.xsl";
@@ -102,17 +102,17 @@ class ProfileResolutionTests {
     return profileResolver;
   }
 
-  private Catalog resolveProfile(@Nonnull Path profileFile)
-      throws FileNotFoundException, BindingException, IOException {
+  private static Catalog resolveProfile(@NonNull Path profileFile)
+      throws FileNotFoundException, IOException, ProfileResolutionException {
     return (Catalog) getProfileResolver().resolveProfile(profileFile).getValue();
   }
 
-  private Catalog resolveProfile(@Nonnull File profileFile)
-      throws FileNotFoundException, BindingException, IOException {
+  private static Catalog resolveProfile(@NonNull File profileFile)
+      throws FileNotFoundException, IOException, ProfileResolutionException {
     return (Catalog) getProfileResolver().resolveProfile(profileFile).getValue();
   }
 
-  private String transformXml(Source source) throws SaxonApiException {
+  private static String transformXml(Source source) throws SaxonApiException {
     net.sf.saxon.s9api.Serializer out = getProcessor().newSerializer();
     out.setOutputProperty(net.sf.saxon.s9api.Serializer.Property.METHOD, "xml");
     // out.setOutputProperty(net.sf.saxon.s9api.Serializer.Property.INDENT, "yes");
@@ -128,16 +128,16 @@ class ProfileResolutionTests {
 
   @ParameterizedTest
   @CsvFileSource(resources = "/profile-tests.csv", numLinesToSkip = 1)
-  void test(String profileName) throws IllegalStateException, IOException, BindingException, SaxonApiException {
+  void test(String profileName) throws IOException, SaxonApiException, ProfileResolutionException {
     performTest(profileName);
   }
 
   @Test
-  void testSingle() throws IllegalStateException, IOException, BindingException, SaxonApiException {
-    performTest("merge-keep-resources");
+  void testSingle() throws IOException, SaxonApiException, ProfileResolutionException {
+    performTest("modify-adds");
   }
 
-  void performTest(String profileName) throws IllegalStateException, IOException, BindingException, SaxonApiException {
+  void performTest(String profileName) throws IOException, SaxonApiException, ProfileResolutionException {
     String profileLocation = String.format("%s/%s_profile.xml", PROFILE_UNIT_TEST_PATH, profileName);
 
     File profileFile = new File(profileLocation);
@@ -152,7 +152,7 @@ class ProfileResolutionTests {
     Assertions.assertThat(catalog.getMetadata().getProps()).filteredOn("name", "resolution-tool").extracting("value")
         .hasSize(1);
 
-    ISerializer<@Nonnull Catalog> serializer = OscalBindingContext.instance().newSerializer(Format.XML, Catalog.class);
+    ISerializer<Catalog> serializer = OscalBindingContext.instance().newSerializer(Format.XML, Catalog.class);
     StringWriter writer = new StringWriter();
     serializer.serialize(catalog, writer);
 
@@ -170,7 +170,7 @@ class ProfileResolutionTests {
   }
 
   @Test
-  void testBrokenLink() throws IllegalStateException, IOException, BindingException {
+  void testBrokenLink() {
     String profileLocation = String.format("%s/broken_profile.xml", PROFILE_UNIT_TEST_PATH);
 
     File profileFile = new File(profileLocation);
@@ -181,12 +181,11 @@ class ProfileResolutionTests {
   }
 
   @Test
-  void testCircularLink() throws IllegalStateException, IOException, BindingException {
+  void testCircularLink() {
     String profileLocation = String.format("%s/circular_profile.xml", PROFILE_UNIT_TEST_PATH);
 
     File profileFile = new File(profileLocation);
 
-    @SuppressWarnings("null")
     IOException exceptionThrown = assertThrows(IOException.class, () -> {
       resolveProfile(profileFile);
     });
@@ -195,7 +194,7 @@ class ProfileResolutionTests {
   }
 
   @Test
-  void testOscalVersion() throws IllegalStateException, IOException, BindingException {
+  void testOscalVersion() throws IOException, ProfileResolutionException {
     Path profileFile = Paths.get(JUNIT_TEST_PATH, "content/test-oscal-version-profile.xml");
     Catalog catalog = resolveProfile(profileFile);
     assertNotNull(catalog);
@@ -203,7 +202,7 @@ class ProfileResolutionTests {
   }
 
   @Test
-  void testImportResourceRelativeLink() throws IOException, BindingException {
+  void testImportResourceRelativeLink() throws IOException, ProfileResolutionException {
     Path profilePath = Paths.get(JUNIT_TEST_PATH, "content/profile-relative-links-resource.xml");
     Catalog resolvedCatalog = resolveProfile(profilePath);
     assertNotNull(resolvedCatalog);

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/TestUtil.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/TestUtil.java
@@ -33,43 +33,45 @@ import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import gov.nist.secauto.oscal.lib.model.Catalog;
-import gov.nist.secauto.oscal.lib.model.CatalogGroup;
-import gov.nist.secauto.oscal.lib.model.Control;
-import gov.nist.secauto.oscal.lib.model.ControlPart;
-import gov.nist.secauto.oscal.lib.model.Parameter;
-import gov.nist.secauto.oscal.lib.model.Property;
-import javax.annotation.Nonnull;
+import gov.nist.secauto.oscal.lib.model.control.AbstractParameter;
+import gov.nist.secauto.oscal.lib.model.control.AbstractPart;
+import gov.nist.secauto.oscal.lib.model.control.catalog.AbstractCatalogGroup;
+import gov.nist.secauto.oscal.lib.model.control.catalog.AbstractControl;
+import gov.nist.secauto.oscal.lib.model.metadata.AbstractProperty;
+import gov.nist.secauto.oscal.lib.model.metadata.IProperty;
 
 import java.nio.file.Paths;
 import java.util.UUID;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public final class TestUtil {
 
-  @Nonnull
+  @NonNull
   public static final IIdentifierMapper UUID_CONCAT_ID_MAPPER = new IIdentifierMapper() {
 
     @Override
-    public String mapRoleIdentifier(@Nonnull String identifier) {
+    public String mapRoleIdentifier(@NonNull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public String mapControlIdentifier(@Nonnull String identifier) {
+    public String mapControlIdentifier(@NonNull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public String mapGroupIdentifier(@Nonnull String identifier) {
+    public String mapGroupIdentifier(@NonNull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public String mapParameterIdentifier(@Nonnull String identifier) {
+    public String mapParameterIdentifier(@NonNull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public @Nonnull String mapPartIdentifier(@Nonnull String identifier) {
+    public @NonNull String mapPartIdentifier(@NonNull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
   };
@@ -78,86 +80,86 @@ public final class TestUtil {
     // disable construction
   }
 
-  @Nonnull
+  @NonNull
   public static IDocumentNodeItem newImportedCatalog() {
 
     // setup the imported catalog
     Catalog importedCatalog = new Catalog();
     importedCatalog.setUuid(UUID.randomUUID());
 
-    importedCatalog.addParam(Parameter.builder("param1")
+    importedCatalog.addParam(AbstractParameter.builder("param1")
         .build());
 
-    importedCatalog.addGroup(CatalogGroup.builder("group1")
+    importedCatalog.addGroup(AbstractCatalogGroup.builder("group1")
         .title("Group 1")
-        .part(ControlPart.builder("statement") // NOPMD - no need to reduce literals
+        .part(AbstractPart.builder("statement") // NOPMD - no need to reduce literals
             .prose("group 1 part 1")
             .build())
-        .param(Parameter.builder("param2")
+        .param(AbstractParameter.builder("param2")
             .build())
-        .control(Control.builder("control1")
+        .control(AbstractControl.builder("control1")
             .title("Control 1")
-            .param(Parameter.builder("param3")
+            .param(AbstractParameter.builder("param3")
                 .build())
-            .part(ControlPart.builder("statement")
+            .part(AbstractPart.builder("statement")
                 .prose("A {{ insert: param, param1}} reference.")
                 .build())
-            .part(ControlPart.builder("statement")
+            .part(AbstractPart.builder("statement")
                 .prose("group 1 control 1 part 1")
-                .part(ControlPart.builder("statement")
+                .part(AbstractPart.builder("statement")
                     .prose("group 1 control 1 part 1.a")
                     .build())
-                .part(ControlPart.builder("statement")
+                .part(AbstractPart.builder("statement")
                     .prose("group 1 control 1 part 1.b")
                     .build())
                 .build())
-            .part(ControlPart.builder("statement")
+            .part(AbstractPart.builder("statement")
                 .prose("group 1 control 1 part 2")
                 .build())
             .build())
         // to be filtered
-        .control(Control.builder("control2")
+        .control(AbstractControl.builder("control2")
             .title("Control 2")
-            .part(ControlPart.builder("statement")
+            .part(AbstractPart.builder("statement")
                 .prose("A {{ insert: param, param2}} reference.")
                 .build())
             .build())
         .build());
-    importedCatalog.addGroup(CatalogGroup.builder("group2")
+    importedCatalog.addGroup(AbstractCatalogGroup.builder("group2")
         .title("Group 2")
-        .param(Parameter.builder("param4")
-            .prop(Property.builder("aggregates")
-                .namespace(Property.RMF_NAMESPACE)
+        .param(AbstractParameter.builder("param4")
+            .prop(AbstractProperty.builder("aggregates")
+                .namespace(IProperty.RMF_NAMESPACE)
                 .value("param2")
                 .build())
             .build())
-        .control(Control.builder("control3")
+        .control(AbstractControl.builder("control3")
             .title("Control 3")
             .build())
-        .control(Control.builder("control4")
+        .control(AbstractControl.builder("control4")
             .title("Control 4")
             .build())
-        .group(CatalogGroup.builder("group3")
+        .group(AbstractCatalogGroup.builder("group3")
             .title("Group 3")
             // to be filtered
-            .control(Control.builder("control5")
+            .control(AbstractControl.builder("control5")
                 .title("Control 5")
                 .build())
             .build())
-        .control(Control.builder("control6")
+        .control(AbstractControl.builder("control6")
             .title("Control 6")
-            .part(ControlPart.builder("statement")
+            .part(AbstractPart.builder("statement")
                 .prose("A {{ insert: param, param4}} reference.")
                 .build())
             .build())
         // to be filtered
-        .control(Control.builder("control7")
+        .control(AbstractControl.builder("control7")
             .title("Control 7")
-            .param(Parameter.builder("param5")
+            .param(AbstractParameter.builder("param5")
                 .build())
-            .control(Control.builder("control8")
+            .control(AbstractControl.builder("control8")
                 .title("Control 8")
-                .part(ControlPart.builder("statement")
+                .part(AbstractPart.builder("statement")
                     .prose("A {{ insert: param, param5}} reference.")
                     .build())
                 .build())
@@ -166,7 +168,8 @@ public final class TestUtil {
 
     return DefaultNodeItemFactory.instance().newDocumentNodeItem(
         IRootAssemblyDefinition.toRootAssemblyDefinition(
-            (IAssemblyClassBinding) OscalBindingContext.instance().getClassBinding(Catalog.class)),
+            ObjectUtils.notNull(
+                (IAssemblyClassBinding) OscalBindingContext.instance().getClassBinding(Catalog.class))),
         importedCatalog,
         ObjectUtils.notNull(Paths.get("").toUri()));
   }

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/TestUtil.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/TestUtil.java
@@ -38,38 +38,38 @@ import gov.nist.secauto.oscal.lib.model.Control;
 import gov.nist.secauto.oscal.lib.model.ControlPart;
 import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.Property;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.nio.file.Paths;
 import java.util.UUID;
 
 public final class TestUtil {
 
-  @NotNull
+  @Nonnull
   public static final IIdentifierMapper UUID_CONCAT_ID_MAPPER = new IIdentifierMapper() {
 
     @Override
-    public String mapRoleIdentifier(@NotNull String identifier) {
+    public String mapRoleIdentifier(@Nonnull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public String mapControlIdentifier(@NotNull String identifier) {
+    public String mapControlIdentifier(@Nonnull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public String mapGroupIdentifier(@NotNull String identifier) {
+    public String mapGroupIdentifier(@Nonnull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public String mapParameterIdentifier(@NotNull String identifier) {
+    public String mapParameterIdentifier(@Nonnull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
 
     @Override
-    public @NotNull String mapPartIdentifier(@NotNull String identifier) {
+    public @Nonnull String mapPartIdentifier(@Nonnull String identifier) {
       return identifier + "-" + UUID.randomUUID().toString();
     }
   };
@@ -78,7 +78,7 @@ public final class TestUtil {
     // disable construction
   }
 
-  @NotNull
+  @Nonnull
   public static IDocumentNodeItem newImportedCatalog() {
 
     // setup the imported catalog

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitorTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitorTest.java
@@ -28,6 +28,7 @@ package gov.nist.secauto.oscal.lib.profile.resolver.policy;
 
 import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.model.common.metapath.item.IDocumentNodeItem;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.profile.resolver.ControlSelectionVisitor;
@@ -42,6 +43,7 @@ import java.io.IOException;
 
 class ReferenceCountingVisitorTest {
 
+  @SuppressWarnings("null")
   @Test
   void test() throws IOException {
     // setup the imported catalog
@@ -65,7 +67,7 @@ class ReferenceCountingVisitorTest {
 
     OscalBindingContext.instance()
         .newSerializer(Format.YAML, Catalog.class)
-        .serialize((Catalog) importedCatalogDocumentItem.getValue(), System.out);
+        .serialize(ObjectUtils.requireNonNull((Catalog) importedCatalogDocumentItem.getValue()), System.out);
   }
 
 }

--- a/src/test/resources/profile-tests.csv
+++ b/src/test/resources/profile-tests.csv
@@ -11,4 +11,4 @@ include-loose-param-test
 include-match-test
 merge-implicit-keep
 merge-keep-resources
-#modify-adds
+modify-adds


### PR DESCRIPTION
# Committer Notes

- Added support for OSCAL profile alter statements supporting `set-parameter`, `add`, and `remove` functions.
- Refactored build to eliminate extraneous dependencies.
- Updated to latest OSCAL development build.
- Setup auto-service generation for OSCAL Metapath function extensions.

Resolves #46.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
