### PR TITLE
Extend `AbstractOscalInstance` for all document types

### DIFF
--- a/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
+++ b/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
@@ -105,6 +105,7 @@
 		href="../../../oscal/src/metaschema/oscal_component_metaschema.xml">
 		<define-assembly-binding name="component">
 			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
 				<use-class-name>ComponentData</use-class-name>
 			</java>
 		</define-assembly-binding>
@@ -126,4 +127,37 @@
 			</java>
 		</define-assembly-binding>
 	</metaschema-binding>
+	<metaschema-binding
+		href="../../../oscal/src/metaschema/oscal_ssp_metaschema.xml">
+		<define-assembly-binding name="system-security-plan">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
+			</java>
+		</define-assembly-binding>
+	</metaschema-binding>
+	<metaschema-binding
+		href="../../../oscal/src/metaschema/oscal_poam_metaschema.xml">
+		<define-assembly-binding name="plan-of-action-and-milestones">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
+			</java>
+		</define-assembly-binding>
+	</metaschema-binding>
+	<metaschema-binding
+		href="../../../oscal/src/metaschema/oscal_assessment-plan_metaschema.xml">
+		<define-assembly-binding name="assessment-plan">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
+			</java>
+		</define-assembly-binding>
+	</metaschema-binding>
+	<metaschema-binding
+		href="../../../oscal/src/metaschema/oscal_assessment-restults_metaschema.xml">
+		<define-assembly-binding name="assessment-results">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
+			</java>
+		</define-assembly-binding>
+	</metaschema-binding>
+
 </metaschema-bindings>


### PR DESCRIPTION
# Committer Notes

Currently only `Catalog` and `Profile` extend `AbstractOscalInstance`
which means that it's currently hard to be generic over all document
types (`<T extends IOscalInstance>`).

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website and readme documentation affected by the changes you made?~
