### PR TITLE
Update checkout configuration in GHA CI/CD for proper version string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         token: ${{ github.token }}
         submodules: recursive
+        fetch-depth: 0
     # -------------------------
     # Java Environment Setup
     # -------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         token: ${{ github.token }}
         submodules: recursive
+        fetch-depth: 0
     # -------------------------
     # Java
     # -------------------------


### PR DESCRIPTION
# Committer Notes

Currently, the locally built copies of the liboscal-java library does
correctly encode version information based on short ID for commits and
tags. This behavior functions correctly because the `git clone` for
normal operations retrieves full history so you can properly analyze
commits and find the latest tag.

This behavior does not work with the default behavior (and arguments),
as of actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9, does
not get that history. This commit configures GitHub CI/CD with this
action to fetch the full history of the repo to do it correctly.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website and readme documentation affected by the changes you made?~
