### PR TITLE
Update liboscal-java to OSCAL v1.2.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# default
+* text=auto
+
+# structured formats
+*.css   text eol=lf
+*.dtd   text eol=lf
+*.ent   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.sch	text eol=lf
+*.scss	text eol=lf
+*.xml   text eol=lf
+*.xpl   text eol=lf
+*.xsd   text eol=lf
+*.xsl   text eol=lf
+*.xspec text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+
+# markdown
+*.md text eol=lf
+
+# script files
+*.sh text eol=lf
+/build/ci-cd/config/* text eol=lf
+
+# programming language files
+*.py    text eol=lf
+*.ts    text eol=lf
+
+# other binary files
+*.png binary
+*.jpg binary

--- a/src/main/java-templates/gov/nist/secauto/oscal/lib/LibOscalVersion.java
+++ b/src/main/java-templates/gov/nist/secauto/oscal/lib/LibOscalVersion.java
@@ -43,7 +43,7 @@ public final class LibOscalVersion implements IVersionInfo {
 
   @Override
   public String getVersion() {
-    return CLOSEST_TAG;
+    return BUILD_VERSION;
   }
 
   @Override

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/profile/AbstractProfileSelectControlById.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/profile/AbstractProfileSelectControlById.java
@@ -27,7 +27,7 @@
 package gov.nist.secauto.oscal.lib.model.control.profile;
 
 import gov.nist.secauto.oscal.lib.model.Matching;
-import gov.nist.secauto.oscal.lib.model.ProfileSelectControlById;
+import gov.nist.secauto.oscal.lib.model.SelectControlById;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -75,8 +75,8 @@ public abstract class AbstractProfileSelectControlById implements IProfileSelect
     }
 
     @NonNull
-    public ProfileSelectControlById build() {
-      ProfileSelectControlById retval = new ProfileSelectControlById();
+    public SelectControlById build() {
+      SelectControlById retval = new SelectControlById();
       retval.setWithChildControls(withChildControls ? "yes" : "no");
       retval.setWithIds(withIds);
       retval.setMatching(matching.stream()

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
@@ -581,7 +581,7 @@ public class ProfileResolver {
                 remove.getByName(),
                 remove.getByClass(),
                 remove.getById(),
-                remove.getByNs(),
+                remove.getByNs() == null ? null : remove.getByNs().toString(),
                 RemoveVisitor.TargetType.forFieldName(remove.getByItemName()))) {
               throw new ProfileResolutionEvaluationException(
                   String.format("The remove did not match a valid target"));

--- a/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
+++ b/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
@@ -51,6 +51,11 @@
 				<extend-base-class>gov.nist.secauto.oscal.lib.model.control.AbstractPart</extend-base-class>
 			</java>
 		</define-assembly-binding>
+		<define-assembly-binding name="select-control-by-id">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.control.profile.AbstractProfileSelectControlById</extend-base-class>
+			</java>
+		</define-assembly-binding>
 	</metaschema-binding>
 	<metaschema-binding
 		href="../../../oscal/src/metaschema/oscal_catalog_metaschema.xml">
@@ -87,12 +92,6 @@
 		<define-assembly-binding name="group">
 			<java>
 				<use-class-name>ProfileGroup</use-class-name>
-			</java>
-		</define-assembly-binding>
-		<define-assembly-binding name="select-control-by-id">
-			<java>
-				<use-class-name>ProfileSelectControlById</use-class-name>
-				<extend-base-class>gov.nist.secauto.oscal.lib.model.control.profile.AbstractProfileSelectControlById</extend-base-class>
 			</java>
 		</define-assembly-binding>
 		<define-assembly-binding name="set-parameter">


### PR DESCRIPTION
Update liboscal-java to OSCAL v1.2.2
- fixes getByNS URI vs String error in `ProfileResolver`
- moves `select-control-by-id` metaschema bindings from profile to control-common, aligning with OSCAL 1.2.2 updates
- updates profile builder to use SelectControlById
- adds a root .gitattributes to reduce newline-only diffs during build
- Fixed `getVersion()` in `LibOscalVersion.java` to correctly return the build version, rather than the git tag of the latest release, which is already done by another function in the file