### PR TITLE
Eliminate disabled tests

### DIFF
--- a/src/test/java/gov/nist/secauto/oscal/java/ExamplesTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/ExamplesTest.java
@@ -78,7 +78,6 @@ class ExamplesTest {
     serializer.serialize(catalog, ObjectUtils.notNull(outDir.resolve("test-catalog.yaml")));
   }
 
-  @Disabled
   @Test
   void testConstraintValidation()
       throws MalformedURLException, IOException, URISyntaxException, ProfileResolutionException {

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
@@ -182,7 +182,8 @@ class ProfileResolutionTests {
     StringWriter writer = new StringWriter();
     serializer.serialize(catalog, writer);
 
-    // OscalBindingContext.instance().newSerializer(Format.YAML, Catalog.class).serialize(catalog,
+    // OscalBindingContext.instance().newSerializer(Format.YAML,
+    // Catalog.class).serialize(catalog,
     // System.out);
 
     // System.out.println("Pre scrub: " + writer.getBuffer().toString());
@@ -238,12 +239,11 @@ class ProfileResolutionTests {
   }
 
   @Test
-  @Disabled
   void testRemove() throws IOException, ProfileResolutionException, URISyntaxException {
-    URL url = new URL(
-        "https://raw.githubusercontent.com/GSA/fedramp-automation/2229f10cc0b143410522026b793f4947eebb0872/dist/content/baselines/rev4/xml/FedRAMP_rev4_LI-SaaS-baseline_profile.xml");
+    Path path = Paths.get(JUNIT_TEST_PATH, "content/profile-remove.xml");
+    assert path != null;
 
-    Catalog resolvedCatalog = resolveProfile(url);
+    Catalog resolvedCatalog = resolveProfile(path);
     assertNotNull(resolvedCatalog);
   }
 

--- a/src/test/resources/content/profile-remove.xml
+++ b/src/test/resources/content/profile-remove.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile xmlns="http://csrc.nist.gov/ns/oscal/1.0"
+    uuid="df19324b-aa44-4e22-a4d2-397bdc6bbaab">
+    <metadata>
+        <title>profile testing removing controls</title>
+        <last-modified>2026-07-13T10:54:16-04:00</last-modified>
+        <version>1.0.0</version>
+        <oscal-version>1.2.2</oscal-version>
+    </metadata>
+    <import href="test-oscal-version-profile.xml">
+      <include-all/>
+	</import>
+	<modify>
+		<alter control-id="b1">
+			<remove by-name="statement"></remove>
+		</alter>
+	</modify>
+</profile>


### PR DESCRIPTION
Enabled `testConstraintValidation` test, and rewrote `testRemove` so it could be enabled. `testRemove` had relied on a URL to a profile that no longer works, so included is a simple profile using the feature intended to be tested instead.
