### PR TITLE
Sync develop with main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 		<dependency.metaschema-framework.version>0.12.2</dependency.metaschema-framework.version>
 
 		<dependency.auto-service.version>1.1.1</dependency.auto-service.version>
-		<dependency.commons-lang3.version>3.14.0</dependency.commons-lang3.version>
+		<dependency.commons-lang3.version>3.18.0</dependency.commons-lang3.version>
 		<dependency.infinispan.version>13.0.10.Final</dependency.infinispan.version>
 		<dependency.jetbrains-annotation.version>23.0.0</dependency.jetbrains-annotation.version>
 		<dependency.jmock-junit5.version>2.12.0</dependency.jmock-junit5.version>


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.14.0 to 3.18.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-lang3 dependency-version: 3.18.0 dependency-type: direct:production ...

