### PR TITLE
Fix mvn install git status clutter

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IControlContainer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IControlContainer.java
@@ -48,7 +48,8 @@ public interface IControlContainer {
   boolean addControl(@NonNull Control item);
 
   /**
-   * Remove the first matching {@link Control} item from the underlying collection.
+   * Remove the first matching {@link Control} item from the underlying
+   * collection.
    *
    * @param item
    *          the item to remove
@@ -68,7 +69,8 @@ public interface IControlContainer {
   boolean addParam(@NonNull Parameter item);
 
   /**
-   * Remove the first matching {@link Parameter} item from the underlying collection.
+   * Remove the first matching {@link Parameter} item from the underlying
+   * collection.
    *
    * @param item
    *          the item to remove
@@ -77,7 +79,8 @@ public interface IControlContainer {
   boolean removeParam(@NonNull Parameter item);
 
   /**
-   * Get the parameter identifiers referenced in the object's context, but not by their child objects.
+   * Get the parameter identifiers referenced in the object's context, but not by
+   * their child objects.
    *
    * @return a stream of identifiers
    */

--- a/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IGroupContainer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/model/control/catalog/IGroupContainer.java
@@ -46,7 +46,8 @@ public interface IGroupContainer extends IControlContainer {
   boolean addGroup(@NonNull CatalogGroup item);
 
   /**
-   * Remove the first matching {@link CatalogGroup} item from the underlying collection.
+   * Remove the first matching {@link CatalogGroup} item from the underlying
+   * collection.
    *
    * @param item
    *          the item to remove

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionException.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionException.java
@@ -47,8 +47,8 @@ public class ProfileResolutionException
   }
 
   /**
-   * Create a new profile resolution exception with the provided {@code message} based on the provided
-   * {@code cause}.
+   * Create a new profile resolution exception with the provided {@code message}
+   * based on the provided {@code cause}.
    *
    * @param message
    *          a description of the error that occurred

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
@@ -115,7 +115,8 @@ public class ProfileResolver {
   private DynamicContext dynamicContext;
 
   /**
-   * Gets the configured loader or creates a new default loader if no loader was configured.
+   * Gets the configured loader or creates a new default loader if no loader was
+   * configured.
    *
    * @return the bound loader
    */
@@ -340,7 +341,8 @@ public class ProfileResolver {
       IDocumentNodeItem document = getDynamicContext().getDocumentLoader().loadAsNodeItem(source);
       IDocumentNodeItem importedCatalog = resolve(document, importHistory);
 
-      // Create a defensive deep copy of the document and associated values, since we will be making
+      // Create a defensive deep copy of the document and associated values, since we
+      // will be making
       // changes to the data.
       try {
         importedCatalog = DefaultNodeItemFactory.instance().newDocumentNodeItem(

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/AddVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/AddVisitor.java
@@ -95,8 +95,8 @@ public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> 
      *
      * @param clazz
      *          the class to identify the target type for
-     * @return the associated target type or {@code null} if the class is not associated with a target
-     *         type
+     * @return the associated target type or {@code null} if the class is not
+     *         associated with a target type
      */
     @Nullable
     public static TargetType forClass(@NonNull Class<?> clazz) {
@@ -114,8 +114,8 @@ public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> 
      *
      * @param name
      *          the field name to identify the target type for
-     * @return the associated target type or {@code null} if the name is not associated with a target
-     *         type
+     * @return the associated target type or {@code null} if the name is not
+     *         associated with a target type
      */
     @Nullable
     public static TargetType forFieldName(@Nullable String name) {
@@ -168,7 +168,8 @@ public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> 
      *
      * @param name
      *          the name to identify the position for
-     * @return the associated position or {@code null} if the name is not associated with a position
+     * @return the associated position or {@code null} if the name is not associated
+     *         with a position
      */
     @Nullable
     public static Position forName(@Nullable String name) {
@@ -257,8 +258,8 @@ public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> 
    * <li>the context matches if:
    * <ul>
    * <li>the target item's id matches the "by-id"; or</li>
-   * <li>the "by-id" is not defined and the target item is the control matching the target
-   * context</li>
+   * <li>the "by-id" is not defined and the target item is the control matching
+   * the target context</li>
    * </ul>
    * </li>
    * </ol>
@@ -268,7 +269,8 @@ public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> 
    * @param targetItem
    *          the current target to process
    * @param titleConsumer
-   *          a consumer to apply a title to or {@code null} if the object has no title field
+   *          a consumer to apply a title to or {@code null} if the object has no
+   *          title field
    * @param paramsSupplier
    *          a supplier for the child {@link Parameter} collection
    * @param propsSupplier
@@ -332,7 +334,8 @@ public class AddVisitor implements ICatalogVisitor<Boolean, AddVisitor.Context> 
   // boolean handleChildren = !Collections.disjoint(context.getTargetItemTypes(),
   // getApplicableTypes(itemType));
   // if (handleChildren && handler != null) {
-  // // if the child item type is applicable and there is a handler, iterate over children
+  // // if the child item type is applicable and there is a handler, iterate over
+  // children
   // Iterator<T> iter = collectionSupplier.get().iterator();
   // while (iter.hasNext()) {
   // T item = iter.next();

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/RemoveVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/RemoveVisitor.java
@@ -93,8 +93,8 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
      *
      * @param clazz
      *          the class to identify the target type for
-     * @return the associated target type or {@code null} if the class is not associated with a target
-     *         type
+     * @return the associated target type or {@code null} if the class is not
+     *         associated with a target type
      */
     @Nullable
     public static TargetType forClass(@NonNull Class<?> clazz) {
@@ -112,8 +112,8 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
      *
      * @param name
      *          the field name to identify the target type for
-     * @return the associated target type or {@code null} if the name is not associated with a target
-     *         type
+     * @return the associated target type or {@code null} if the name is not
+     *         associated with a target type
      */
     @Nullable
     public static TargetType forFieldName(@Nullable String name) {
@@ -184,7 +184,8 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
         }
       }
     } else if (handleChildren && handler != null) {
-      // if the child item type is applicable and there is a handler, iterate over children
+      // if the child item type is applicable and there is a handler, iterate over
+      // children
       Iterator<T> iter = supplier.get().iterator();
       while (iter.hasNext()) {
         T item = iter.next();
@@ -394,7 +395,8 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
         @Nullable TargetType itemType) {
 
       // determine the set of effective item types to search for
-      // this helps with short-circuit searching for parts of the graph that cannot match
+      // this helps with short-circuit searching for parts of the graph that cannot
+      // match
       @NonNull Set<TargetType> targetItemTypes = ObjectUtils.notNull(EnumSet.allOf(TargetType.class));
       filterTypes(targetItemTypes, "by-name", NAME_TYPES, objectName, itemType);
       filterTypes(targetItemTypes, "by-class", CLASS_TYPES, objectClass, itemType);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/merge/FlatteningStructuringVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/merge/FlatteningStructuringVisitor.java
@@ -238,8 +238,10 @@ public class FlatteningStructuringVisitor
         if (parent.getValue() instanceof Control && SelectionStatus.SELECTED.equals(index.getSelectionStatus(parent))) {
           retval.removeControl(control);
         }
-        // Cancel promotion of this control if control is already at the top level (control's parent is Catalog)
-        // If already at top level, then promotion is not needed because it was added by Import class
+        // Cancel promotion of this control if control is already at the top level
+        // (control's parent is Catalog)
+        // If already at top level, then promotion is not needed because it was added by
+        // Import class
         if (parent.getValue() instanceof Catalog) {
           retval.removeControl(control);
         }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractCustomReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AbstractCustomReferencePolicy.java
@@ -57,10 +57,11 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
   }
 
   /**
-   * Get the possible item types that can be searched in the order in which the identifier will be
-   * looked up.
+   * Get the possible item types that can be searched in the order in which the
+   * identifier will be looked up.
    * <p>
-   * The {@code reference} object is provided to allow for context sensitive item type tailoring.
+   * The {@code reference} object is provided to allow for context sensitive item
+   * type tailoring.
    *
    * @param reference
    *          the reference object
@@ -79,7 +80,8 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    * @param item
    *          the referenced item
    * @param visitorContext
-   *          the reference visitor state, which can be used for further processing
+   *          the reference visitor state, which can be used for further
+   *          processing
    * @return {@code true} if the hit was handled or {@code false} otherwise
    * @throws ProfileResolutionEvaluationException
    *           if there was an error handing the index hit
@@ -149,7 +151,8 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    * @param item
    *          the referenced item
    * @param visitorContext
-   *          the reference visitor state, which can be used for further processing
+   *          the reference visitor state, which can be used for further
+   *          processing
    * @throws ProfileResolutionEvaluationException
    *           if there was an error handing the index hit
    */
@@ -162,8 +165,8 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
   }
 
   /**
-   * Handle an index miss for a reference. This occurs when the referenced item was not found in the
-   * index.
+   * Handle an index miss for a reference. This occurs when the referenced item
+   * was not found in the index.
    * <p>
    * Subclasses can override this method to perform extra processing.
    *
@@ -176,8 +179,10 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    * @param identifier
    *          the parsed identifier
    * @param visitorContext
-   *          the reference visitor state, which can be used for further processing
-   * @return {@code true} if the reference is handled by this method or {@code false} otherwise
+   *          the reference visitor state, which can be used for further
+   *          processing
+   * @return {@code true} if the reference is handled by this method or
+   *         {@code false} otherwise
    * @throws ProfileResolutionEvaluationException
    *           if there was an error handing the index miss
    */
@@ -192,8 +197,9 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
   }
 
   /**
-   * Handle the case where the identifier was not a syntax match for an expected identifier. This can
-   * occur when the reference is malformed, using an unrecognized syntax.
+   * Handle the case where the identifier was not a syntax match for an expected
+   * identifier. This can occur when the reference is malformed, using an
+   * unrecognized syntax.
    * <p>
    * Subclasses can override this method to perform extra processing.
    *
@@ -202,8 +208,10 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    * @param reference
    *          the identifier reference object generating the hit
    * @param visitorContext
-   *          the reference visitor state, which can be used for further processing
-   * @return {@code true} if the reference is handled by this method or {@code false} otherwise
+   *          the reference visitor state, which can be used for further
+   *          processing
+   * @return {@code true} if the reference is handled by this method or
+   *         {@code false} otherwise
    * @throws ProfileResolutionEvaluationException
    *           if there was an error handing the index miss due to a non match
    */
@@ -222,7 +230,8 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
       @NonNull ReferenceCountingVisitor.Context visitorContext) {
     String referenceText = getReferenceText(type);
 
-    // if the reference text does not exist, ignore the reference; otherwise, handle it.
+    // if the reference text does not exist, ignore the reference; otherwise, handle
+    // it.
     return referenceText == null
         || handleIdentifier(contextItem, type, getIdentifierParser().parse(referenceText), visitorContext);
   }
@@ -237,8 +246,10 @@ public abstract class AbstractCustomReferencePolicy<TYPE> implements ICustomRefe
    * @param identifier
    *          the identifier
    * @param visitorContext
-   *          the reference visitor state, which can be used for further processing
-   * @return {@code true} if the reference is handled by this method or {@code false} otherwise
+   *          the reference visitor state, which can be used for further
+   *          processing
+   * @return {@code true} if the reference is handled by this method or
+   *         {@code false} otherwise
    * @throws ProfileResolutionEvaluationException
    *           if there was an error handing the reference
    */

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicyHandler.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ICustomReferencePolicyHandler.java
@@ -48,8 +48,8 @@ public interface ICustomReferencePolicyHandler<TYPE> {
   };
 
   /**
-   * A callback used to handle the case where an identifier could not be parsed from the reference
-   * text.
+   * A callback used to handle the case where an identifier could not be parsed
+   * from the reference text.
    *
    * @param policy
    *          the reference policy for this reference
@@ -57,7 +57,8 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    *          the reference object
    * @param visitor
    *          the reference visitor used to resolve referenced objects
-   * @return {@code true} if the reference is considered handled, or {@code false} otherwise
+   * @return {@code true} if the reference is considered handled, or {@code false}
+   *         otherwise
    */
   default boolean handleIdentifierNonMatch(
       @NonNull ICustomReferencePolicy<TYPE> policy,
@@ -67,8 +68,8 @@ public interface ICustomReferencePolicyHandler<TYPE> {
   }
 
   /**
-   * A callback used to handle the case where an identifier could be parsed from the reference text,
-   * but the index didn't contain a matching entity.
+   * A callback used to handle the case where an identifier could be parsed from
+   * the reference text, but the index didn't contain a matching entity.
    *
    * @param policy
    *          the reference policy for this reference
@@ -80,7 +81,8 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    *          the parsed identifier
    * @param visitor
    *          the reference visitor used to resolve referenced objects
-   * @return {@code true} if the reference is considered handled, or {@code false} otherwise
+   * @return {@code true} if the reference is considered handled, or {@code false}
+   *         otherwise
    */
   default boolean handleIndexMiss(
       @NonNull ICustomReferencePolicy<TYPE> policy,
@@ -92,8 +94,8 @@ public interface ICustomReferencePolicyHandler<TYPE> {
   }
 
   /**
-   * A callback used to handle the case where an identifier could be parsed and the index contains a
-   * matching entity.
+   * A callback used to handle the case where an identifier could be parsed and
+   * the index contains a matching entity.
    *
    * @param policy
    *          the reference policy for this reference
@@ -103,7 +105,8 @@ public interface ICustomReferencePolicyHandler<TYPE> {
    *          the entity that is referenced
    * @param visitor
    *          the reference visitor used to resolve referenced objects
-   * @return {@code true} if the reference is considered handled, or {@code false} otherwise
+   * @return {@code true} if the reference is considered handled, or {@code false}
+   *         otherwise
    */
   default boolean handleIndexHit(
       @NonNull ICustomReferencePolicy<TYPE> policy,

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IIdentifierParser.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IIdentifierParser.java
@@ -59,7 +59,8 @@ public interface IIdentifierParser {
   String parse(@NonNull String referenceText);
 
   /**
-   * Substitute the provided {@code newIdentifier} with the identifier in the {@code referenceText}.
+   * Substitute the provided {@code newIdentifier} with the identifier in the
+   * {@code referenceText}.
    *
    * @param referenceText
    *          the reference text containing the original identifier

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferenceVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/IReferenceVisitor.java
@@ -43,8 +43,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
 
   /**
-   * Visit the provided {@code item} representing an OSCAL {@link CatalogGroup} and handle any
-   * enclosed references.
+   * Visit the provided {@code item} representing an OSCAL {@link CatalogGroup}
+   * and handle any enclosed references.
    *
    * @param item
    *          the Metapath node item containing reference nodes
@@ -55,8 +55,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   Void visitGroup(@NonNull IRequiredValueModelNodeItem item, Void childResult, T context);
 
   /**
-   * Visit the provided {@code item} representing an OSCAL {@link Control} and handle any enclosed
-   * references.
+   * Visit the provided {@code item} representing an OSCAL {@link Control} and
+   * handle any enclosed references.
    *
    * @param item
    *          the Metapath node item containing reference nodes
@@ -67,7 +67,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   Void visitControl(@NonNull IRequiredValueModelNodeItem item, Void childResult, T context);
   //
   // /**
-  // * Visit the provided {@code item} representing an OSCAL {@link Parameter} and handle any enclosed
+  // * Visit the provided {@code item} representing an OSCAL {@link Parameter} and
+  // handle any enclosed
   // * references.
   // *
   // * @param item
@@ -78,7 +79,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   // void resolveParameter(@NonNull IRequiredValueModelNodeItem item);
   //
   // /**
-  // * Visit the provided {@code item} representing an OSCAL {@link ControlPart} and handle any
+  // * Visit the provided {@code item} representing an OSCAL {@link ControlPart}
+  // and handle any
   // enclosed
   // * references.
   // *
@@ -90,7 +92,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   // void resolvePart(@NonNull IRequiredValueModelNodeItem item, T context);
   //
   // /**
-  // * Visit the provided {@code item} representing an OSCAL {@link Role} and handle any enclosed
+  // * Visit the provided {@code item} representing an OSCAL {@link Role} and
+  // handle any enclosed
   // * references.
   // *
   // * @param item
@@ -101,7 +104,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   // void resolveRole(@NonNull IRequiredValueModelNodeItem item);
   //
   // /**
-  // * Visit the provided {@code item} representing an OSCAL {@link Party} and handle any enclosed
+  // * Visit the provided {@code item} representing an OSCAL {@link Party} and
+  // handle any enclosed
   // * references.
   // *
   // * @param item
@@ -112,7 +116,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   // void resolveParty(@NonNull IRequiredValueModelNodeItem item);
   //
   // /**
-  // * Visit the provided {@code item} representing an OSCAL {@link Location} and handle any enclosed
+  // * Visit the provided {@code item} representing an OSCAL {@link Location} and
+  // handle any enclosed
   // * references.
   // *
   // * @param item
@@ -123,7 +128,8 @@ public interface IReferenceVisitor<T> extends ICatalogVisitor<T, Void> {
   // void resolveLocation(@NonNull IRequiredValueModelNodeItem item);
   //
   // /**
-  // * Visit the provided {@code item} representing an OSCAL {@link Resource} and handle any enclosed
+  // * Visit the provided {@code item} representing an OSCAL {@link Resource} and
+  // handle any enclosed
   // * references.
   // *
   // * @param item

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
@@ -134,7 +134,8 @@ public class ReferenceCountingVisitor
   }
 
   public ReferenceCountingVisitor() {
-    // visit everything except parts, roles, locations, parties, parameters, and resources, which are
+    // visit everything except parts, roles, locations, parties, parameters, and
+    // resources, which are
     // handled differently by this visitor
     super(ObjectUtils.notNull(EnumSet.complementOf(
         EnumSet.of(
@@ -168,7 +169,8 @@ public class ReferenceCountingVisitor
   //
   // BackMatter backMatter = profile.getBackMatter();
   // if (backMatter != null) {
-  // for (BackMatter.Resource resource : CollectionUtil.listOrEmpty(backMatter.getResources())) {
+  // for (BackMatter.Resource resource :
+  // CollectionUtil.listOrEmpty(backMatter.getResources())) {
   // visitResource(resource);
   // }
   // }
@@ -206,7 +208,8 @@ public class ReferenceCountingVisitor
   public Void visitGroup(@NonNull IRequiredValueModelNodeItem item, Void childResult, Context context) {
     IIndexer index = context.getIndexer();
     // handle the group if it is selected
-    // a group will only be selected if it contains a descendant control that is selected
+    // a group will only be selected if it contains a descendant control that is
+    // selected
     if (IIndexer.SelectionStatus.SELECTED.equals(index.getSelectionStatus(item))) {
       CatalogGroup group = (CatalogGroup) item.getValue();
       String id = group.getId();
@@ -385,7 +388,8 @@ public class ReferenceCountingVisitor
     item.getModelItemsByName("prop").forEach(child -> handleProperty(ObjectUtils.notNull(child), context));
     item.getModelItemsByName("link").forEach(child -> handleLink(ObjectUtils.notNull(child), context));
     item.getModelItemsByName("prose").forEach(child -> handleMarkup(ObjectUtils.notNull(child), context));
-    // item.getModelItemsByName("part").forEach(child -> visitor.visitPart(ObjectUtils.notNull(child),
+    // item.getModelItemsByName("part").forEach(child ->
+    // visitor.visitPart(ObjectUtils.notNull(child),
     // context));
   }
 
@@ -536,7 +540,8 @@ public class ReferenceCountingVisitor
   // }
   //
   // @Override
-  // protected Void aggregateResults(Object first, Object second, Object context) {
+  // protected Void aggregateResults(Object first, Object second, Object context)
+  // {
   // return null;
   // }
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/ControlSelectionVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/ControlSelectionVisitor.java
@@ -47,21 +47,24 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * Walks a {@link Catalog} indexing all nodes that can be referenced.
  * <p>
- * For each {@link CatalogGroup}, {@link Control}, and {@link ControlPart}, determine if that object
- * is {@link SelectionStatus#SELECTED} or {@link SelectionStatus#UNSELECTED}.
+ * For each {@link CatalogGroup}, {@link Control}, and {@link ControlPart},
+ * determine if that object is {@link SelectionStatus#SELECTED} or
+ * {@link SelectionStatus#UNSELECTED}.
  * <p>
- * A {@link Control} is {@link SelectionStatus#SELECTED} if it matches the configured
- * {@link IControlFilter}, otherwise it is {@link SelectionStatus#UNSELECTED}.
+ * A {@link Control} is {@link SelectionStatus#SELECTED} if it matches the
+ * configured {@link IControlFilter}, otherwise it is
+ * {@link SelectionStatus#UNSELECTED}.
  * <p>
  * A {@link CatalogGroup} is {@link SelectionStatus#SELECTED} if it contains a
  * {@link SelectionStatus#SELECTED} descendant {@link Control}, otherwise it is
  * {@link SelectionStatus#UNSELECTED}.
  * <p>
- * A {@link ControlPart} is {@link SelectionStatus#SELECTED} if its containing control is
- * {@link SelectionStatus#SELECTED}.
+ * A {@link ControlPart} is {@link SelectionStatus#SELECTED} if its containing
+ * control is {@link SelectionStatus#SELECTED}.
  * <p>
- * All other indexed nodes will have the {@link SelectionStatus#UNKNOWN}, since these nodes require
- * reference counting to determine if they are to be kept or not.
+ * All other indexed nodes will have the {@link SelectionStatus#UNKNOWN}, since
+ * these nodes require reference counting to determine if they are to be kept or
+ * not.
  */
 public class ControlSelectionVisitor
     extends AbstractIndexingVisitor<IControlSelectionState, Boolean> {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/DefaultControlSelectionFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/DefaultControlSelectionFilter.java
@@ -52,7 +52,8 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
   private final List<Selection> selections;
 
   /**
-   * Construct a new selection filter based on the provided list of select criteria.
+   * Construct a new selection filter based on the provided list of select
+   * criteria.
    *
    * @param selections
    *          a list of select criteria
@@ -78,13 +79,14 @@ public class DefaultControlSelectionFilter implements IControlSelectionFilter {
   }
 
   /**
-   * Checks if the provided control identifier matches the criteria defined by this object.
+   * Checks if the provided control identifier matches the criteria defined by
+   * this object.
    *
    * @param id
    *          the control identifier to match
-   * @return a {@link Pair} whose first member is {@code true} for a match or {@code false} otherwise,
-   *         and whose second member is {@code true} if the match applies to any child controls or
-   *         {@code false} otherwise
+   * @return a {@link Pair} whose first member is {@code true} for a match or
+   *         {@code false} otherwise, and whose second member is {@code true} if
+   *         the match applies to any child controls or {@code false} otherwise
    */
   @SuppressWarnings("null")
   @NonNull

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/FilterNonSelectedVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/FilterNonSelectedVisitor.java
@@ -207,8 +207,10 @@ public class FilterNonSelectedVisitor
       control.setId(entity.getIdentifier());
 
       if (!SelectionStatus.SELECTED.equals(index.getSelectionStatus(parent))) {
-        // promote this control if control is not already at the top level (control's parent is Catalog)
-        // If already at top level, then promotion is not needed because it was added by Import class
+        // promote this control if control is not already at the top level (control's
+        // parent is Catalog)
+        // If already at top level, then promotion is not needed because it was added by
+        // Import class
         if (!(parent.getValue() instanceof Catalog)) {
           retval.promoteControl(control);
         }

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/IControlFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/IControlFilter.java
@@ -77,7 +77,8 @@ public interface IControlFilter {
   };
 
   /**
-   * Construct a new filter instance based on the provided profile import statement.
+   * Construct a new filter instance based on the provided profile import
+   * statement.
    *
    * @param profileImport
    *          an OSCAL profile import statement
@@ -95,14 +96,15 @@ public interface IControlFilter {
   }
 
   /**
-   * Determines if the control is matched by this filter. This method returns a {@link Pair} where the
-   * first member of the pair indicates if the control matches, and the second indicates if the match
-   * applies to child controls as well.
+   * Determines if the control is matched by this filter. This method returns a
+   * {@link Pair} where the first member of the pair indicates if the control
+   * matches, and the second indicates if the match applies to child controls as
+   * well.
    *
    * @param control
    *          the control to check for a match
-   * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
-   *         otherwise), and if a match applies to child controls
+   * @return a pair indicating the status of the match ({@code true} for a match
+   *         or {@code false} otherwise), and if a match applies to child controls
    */
   @NonNull
   default Pair<Boolean, Boolean> match(@NonNull IControl control) {
@@ -110,16 +112,17 @@ public interface IControlFilter {
   }
 
   /**
-   * Determines if the control is matched by this filter. This method returns a {@link Pair} where the
-   * first member of the pair indicates if the control matches, and the second indicates if the match
-   * applies to child controls as well.
+   * Determines if the control is matched by this filter. This method returns a
+   * {@link Pair} where the first member of the pair indicates if the control
+   * matches, and the second indicates if the match applies to child controls as
+   * well.
    *
    * @param control
    *          the control to check for a match
    * @param defaultMatch
    *          the match status to use if the filter doesn't have an explicit hit
-   * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
-   *         otherwise), and if a match applies to child controls
+   * @return a pair indicating the status of the match ({@code true} for a match
+   *         or {@code false} otherwise), and if a match applies to child controls
    */
   @NonNull
   Pair<Boolean, Boolean> match(@NonNull IControl control, boolean defaultMatch);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/IControlSelectionFilter.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/IControlSelectionFilter.java
@@ -75,14 +75,15 @@ public interface IControlSelectionFilter extends Function<IControl, Pair<Boolean
   }
 
   /**
-   * Determines if the control is matched by this filter. This method returns a {@link Pair} where the
-   * first member of the pair indicates if the control matches, and the second indicates if the match
-   * applies to child controls as well.
+   * Determines if the control is matched by this filter. This method returns a
+   * {@link Pair} where the first member of the pair indicates if the control
+   * matches, and the second indicates if the match applies to child controls as
+   * well.
    *
    * @param control
    *          the control to check for a match
-   * @return a pair indicating the status of the match ({@code true} for a match or {@code false}
-   *         otherwise), and if a match applies to child controls
+   * @return a pair indicating the status of the match ({@code true} for a match
+   *         or {@code false} otherwise), and if a match applies to child controls
    */
   @NonNull
   @Override

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/AbstractCatalogEntityVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/AbstractCatalogEntityVisitor.java
@@ -42,7 +42,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * Visits a catalog document and its children as designated.
  * <p>
- * This implementation is stateless. The {@code T} parameter can be used to convey state as needed.
+ * This implementation is stateless. The {@code T} parameter can be used to
+ * convey state as needed.
  *
  * @param <T>
  *          the state type
@@ -74,7 +75,8 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   private final Set<IEntityItem.ItemType> itemTypesToVisit;
 
   /**
-   * Create a new visitor that will visit the item types identified by {@code itemTypesToVisit}.
+   * Create a new visitor that will visit the item types identified by
+   * {@code itemTypesToVisit}.
    *
    * @param itemTypesToVisit
    *          the item type the visitor will visit
@@ -173,8 +175,8 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   /**
    * Called when visiting a parameter.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
    *          the Metapath item for the parameter
@@ -195,8 +197,8 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   /**
    * Called when visiting a part.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
    *          the Metapath item for the part
@@ -247,11 +249,12 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   /**
    * Called when visiting a role in the "metadata" section of an OSCAL document.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
-   *          the role Metaschema node item which is a child of the "metadata" node
+   *          the role Metaschema node item which is a child of the "metadata"
+   *          node
    * @param metadataItem
    *          the "metadata" Metaschema node item containing the role
    * @param state
@@ -265,13 +268,15 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   }
 
   /**
-   * Called when visiting a location in the "metadata" section of an OSCAL document.
+   * Called when visiting a location in the "metadata" section of an OSCAL
+   * document.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
-   *          the location Metaschema node item which is a child of the "metadata" node
+   *          the location Metaschema node item which is a child of the "metadata"
+   *          node
    * @param metadataItem
    *          the "metadata" Metaschema node item containing the location
    * @param state
@@ -287,11 +292,12 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   /**
    * Called when visiting a party in the "metadata" section of an OSCAL document.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
-   *          the party Metaschema node item which is a child of the "metadata" node
+   *          the party Metaschema node item which is a child of the "metadata"
+   *          node
    * @param metadataItem
    *          the "metadata" Metaschema node item containing the party
    * @param state
@@ -325,13 +331,15 @@ public abstract class AbstractCatalogEntityVisitor<T, R>
   }
 
   /**
-   * Called when visiting a resource in the "back-matter" section of an OSCAL document.
+   * Called when visiting a resource in the "back-matter" section of an OSCAL
+   * document.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
-   *          the resource Metaschema node item which is a child of the "metadata" node
+   *          the resource Metaschema node item which is a child of the "metadata"
+   *          node
    * @param backMatterItem
    *          the resource Metaschema node item containing the party
    * @param state

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/AbstractCatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/AbstractCatalogVisitor.java
@@ -36,9 +36,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Used to visit a catalog containing groups and controls.
  *
  * @param <T>
- *          the type of the state object used to pass calling context information
+ *          the type of the state object used to pass calling context
+ *          information
  * @param <R>
- *          the type of the result for visiting a collection of groups and/or controls
+ *          the type of the result for visiting a collection of groups and/or
+ *          controls
  */
 public abstract class AbstractCatalogVisitor<T, R> implements ICatalogVisitor<T, R> {
 
@@ -51,7 +53,8 @@ public abstract class AbstractCatalogVisitor<T, R> implements ICatalogVisitor<T,
   }
 
   /**
-   * Visit the child groups and controls (in that order) of a given catalog or group container.
+   * Visit the child groups and controls (in that order) of a given catalog or
+   * group container.
    *
    * @param catalogOrGroup
    *          the catalog or group Metapath item currently being visited
@@ -108,7 +111,8 @@ public abstract class AbstractCatalogVisitor<T, R> implements ICatalogVisitor<T,
   }
 
   /**
-   * Visit the child controls (in that order) of a given catalog, group, or control container.
+   * Visit the child controls (in that order) of a given catalog, group, or
+   * control container.
    *
    * @param catalogOrGroupOrControl
    *          the catalog, group, or control Metapath item currently being visited

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/AbstractEntityItem.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/AbstractEntityItem.java
@@ -66,7 +66,8 @@ public abstract class AbstractEntityItem implements IEntityItem {
   // @NonNull
   // public String getIdentifier() {
   // final String checkedReassignedIdentifier = reassignedIdentifier;
-  // return checkedReassignedIdentifier == null ? originalIdentifier : checkedReassignedIdentifier;
+  // return checkedReassignedIdentifier == null ? originalIdentifier :
+  // checkedReassignedIdentifier;
   // }
 
   @Override

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/BasicIndexer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/BasicIndexer.java
@@ -190,11 +190,14 @@ public class BasicIndexer implements IIndexer {
     return entityGroup == null ? CollectionUtil.emptyList() : ObjectUtils.notNull(entityGroup.values());
   }
   //
-  // public EntityItem getEntity(@NonNull ItemType itemType, @NonNull UUID identifier) {
-  // return getEntity(itemType, ObjectUtils.notNull(identifier.toString()), false);
+  // public EntityItem getEntity(@NonNull ItemType itemType, @NonNull UUID
+  // identifier) {
+  // return getEntity(itemType, ObjectUtils.notNull(identifier.toString()),
+  // false);
   // }
   //
-  // public EntityItem getEntity(@NonNull ItemType itemType, @NonNull String identifier) {
+  // public EntityItem getEntity(@NonNull ItemType itemType, @NonNull String
+  // identifier) {
   // return getEntity(itemType, identifier, itemType.isUuid());
   // }
 
@@ -327,10 +330,11 @@ public class BasicIndexer implements IIndexer {
   /**
    * Create a new builder with the provided info.
    * <p>
-   * This method can be overloaded to support applying additional data to the returned builder.
+   * This method can be overloaded to support applying additional data to the
+   * returned builder.
    * <p>
-   * When working with identifiers that are case insensitve, it is important to ensure that the
-   * identifiers are normalized to lower case.
+   * When working with identifiers that are case insensitve, it is important to
+   * ensure that the identifiers are normalized to lower case.
    *
    * @param item
    *          the Metapath node to associate with the entity

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/ICatalogVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/ICatalogVisitor.java
@@ -34,17 +34,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Used to visit a catalog containing groups and controls.
  *
  * @param <T>
- *          the type of the context object used to pass calling context information
+ *          the type of the context object used to pass calling context
+ *          information
  * @param <R>
- *          the type of the result for visiting a collection of groups and/or controls
+ *          the type of the result for visiting a collection of groups and/or
+ *          controls
  */
 public interface ICatalogVisitor<T, R> {
 
   /**
    * Called when visiting a group.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
    *          the Metapath item for the group
@@ -62,8 +64,8 @@ public interface ICatalogVisitor<T, R> {
   /**
    * Called when visiting a control.
    * <p>
-   * Can be overridden by classes extending this interface to support processing of the visited
-   * object.
+   * Can be overridden by classes extending this interface to support processing
+   * of the visited object.
    *
    * @param item
    *          the Metapath item for the control

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/IEntityItem.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/IEntityItem.java
@@ -58,13 +58,14 @@ public interface IEntityItem {
   /**
    * Get the identifier originally assigned to this entity.
    * <p>
-   * If the identifier value was reassigned, the return value of this method will be different than
-   * value returned by {@link #getIdentifier()}. In such cases, a call to
-   * {@link #isIdentifierReassigned()} is expected to return {@code true}.
+   * If the identifier value was reassigned, the return value of this method will
+   * be different than value returned by {@link #getIdentifier()}. In such cases,
+   * a call to {@link #isIdentifierReassigned()} is expected to return
+   * {@code true}.
    * <p>
-   * If the value was not reassigned, the return value of this method will be the same value returned
-   * by {@link #getIdentifier()}. In this case, {@link #isIdentifierReassigned()} is expected to
-   * return {@code false}.
+   * If the value was not reassigned, the return value of this method will be the
+   * same value returned by {@link #getIdentifier()}. In this case,
+   * {@link #isIdentifierReassigned()} is expected to return {@code false}.
    *
    * @return the original identifier value before reassignment
    */
@@ -82,7 +83,8 @@ public interface IEntityItem {
   /**
    * Determine if the identifier was reassigned.
    *
-   * @return {@code true} if the identifier was reassigned, or {@code false} otherwise
+   * @return {@code true} if the identifier was reassigned, or {@code false}
+   *         otherwise
    */
   boolean isIdentifierReassigned();
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/IIndexer.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/IIndexer.java
@@ -76,8 +76,8 @@ public interface IIndexer {
   }
 
   /**
-   * Keep entities that have a reference count greater than zero or are required to be kept based on
-   * the "keep"="always property.
+   * Keep entities that have a reference count greater than zero or are required
+   * to be kept based on the "keep"="always property.
    *
    * @param entities
    *          the entity items to filter
@@ -88,8 +88,8 @@ public interface IIndexer {
   }
 
   /**
-   * Keep entities that have a reference count of zero or are not required to be kept based on the
-   * "keep"="always property.
+   * Keep entities that have a reference count of zero or are not required to be
+   * kept based on the "keep"="always property.
    *
    * @param entities
    *          the entity items to filter
@@ -100,22 +100,25 @@ public interface IIndexer {
   }
 
   /**
-   * Generates a stream of distinct items that have a reference count greater than zero or are
-   * required to be kept based on the "keep"="always property.
+   * Generates a stream of distinct items that have a reference count greater than
+   * zero or are required to be kept based on the "keep"="always property.
    * <p>
-   * Distinct items are determined based on the item's key using the provided {@code keyMapper}.
+   * Distinct items are determined based on the item's key using the provided
+   * {@code keyMapper}.
    *
    * @param <T>
    *          the item type
    * @param <K>
    *          the key type
    * @param resolvedItems
-   *          a series of previously resolved items to add to prepend to the stream
+   *          a series of previously resolved items to add to prepend to the
+   *          stream
    * @param importedEntityItems
    *          a collection of new items to filter then append to the stream
    * @param keyMapper
    *          the key mapping function to determine the item's key
-   * @return the resulting series of items with duplicate items with the same key removed
+   * @return the resulting series of items with duplicate items with the same key
+   *         removed
    */
   // TODO: Is this the right name for this method?
   static <T, K> Stream<T> filterDistinct(
@@ -193,7 +196,8 @@ public interface IIndexer {
   }
 
   /**
-   * Lookup an item of the given {@code itemType} having the given {@code identifier}.
+   * Lookup an item of the given {@code itemType} having the given
+   * {@code identifier}.
    * <p>
    * Will normalize the case of a UUID-based identifier.
    *
@@ -209,7 +213,8 @@ public interface IIndexer {
   }
 
   /**
-   * Lookup an item of the given {@code itemType} having the given {@code identifier}.
+   * Lookup an item of the given {@code itemType} having the given
+   * {@code identifier}.
    * <p>
    * Will normalize the case of a UUID-based the identifier when requested.
    *
@@ -218,7 +223,8 @@ public interface IIndexer {
    * @param identifier
    *          the identifier to lookup
    * @param normalize
-   *          {@code true} if the identifier case should be normalized or {@code false} otherwise
+   *          {@code true} if the identifier case should be normalized or
+   *          {@code false} otherwise
    * @return the matching item or {@code null} if no match was found
    */
   @Nullable

--- a/src/test/java/gov/nist/secauto/oscal/java/MetaschemaVisitorTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/MetaschemaVisitorTest.java
@@ -80,31 +80,40 @@ class MetaschemaVisitorTest {
     // File("resolved-catalog.xml")));
 
     // evaluatePath(MetapathExpression.compile("resolve-profile(doc(resolve-uri(/profile/import/@href,
-    // document-uri(/profile))))/(profile, catalog)//control/@id"), nodeItem, dynamicContext);
+    // document-uri(/profile))))/(profile, catalog)//control/@id"), nodeItem,
+    // dynamicContext);
     evaluatePath(MetapathExpression.compile("//control/@id"), resolvedProfile, dynamicContext);
     // evaluatePath(MetapathExpression.compile("doc(resolve-uri(/profile/import/@href,
-    // document-uri(/profile)))/catalog/metadata/last-modified"), nodeItem, dynamicContext);
+    // document-uri(/profile)))/catalog/metadata/last-modified"), nodeItem,
+    // dynamicContext);
     // evaluatePath(
     // MetapathExpression.compile("doc(resolve-uri(/profile/import/@href,
-    // document-uri(/profile)))/catalog/metadata/last-modified - /catalog/metadata/last-modified"),
+    // document-uri(/profile)))/catalog/metadata/last-modified -
+    // /catalog/metadata/last-modified"),
     // nodeItem, dynamicContext);
     // evaluatePath(MetapathExpression.compile("doc(resolve-uri(/profile/import/@href,
-    // document-uri(/profile)))/catalog/metadata/last-modified + duration('PT1H')"), nodeItem,
+    // document-uri(/profile)))/catalog/metadata/last-modified + duration('PT1H')"),
+    // nodeItem,
     // dynamicContext);
     // evaluatePath(MetapathExpression.compile("doc(resolve-uri(/profile/import/@href,
     // document-uri(/profile)))/catalog/metadata/last-modified,/catalog/metadata/last-modified"),
     // nodeItem, dynamicContext);
     // evaluatePath(MetapathExpression.compile("doc('target/download/content/NIST_SP-800-53_rev5_catalog.xml')"),
     // nodeItem, dynamicContext);
-    // evaluatePath(Metapath.parseMetapathString("2 eq 1 + 1[/catalog]"), nodeContext, visitor);
+    // evaluatePath(Metapath.parseMetapathString("2 eq 1 + 1[/catalog]"),
+    // nodeContext, visitor);
     // evaluatePath(Metapath.parseMetapathString("/catalog/back-matter/resource[rlink/@href='https://doi.org/10.6028/NIST.SP.800-53r5']"),
     // nodeItem, dynamicContext);
-    // evaluatePath(MetapathExpression.compile("/catalog//(@id,@uuid)"), nodeItem, dynamicContext);
-    // evaluatePath(MetapathExpression.compile("exists(/catalog//(@id,@uuid))"), nodeItem,
+    // evaluatePath(MetapathExpression.compile("/catalog//(@id,@uuid)"), nodeItem,
     // dynamicContext);
-    // evaluatePath(MetapathExpression.compile("/catalog//control//prop/@name"), nodeItem,
+    // evaluatePath(MetapathExpression.compile("exists(/catalog//(@id,@uuid))"),
+    // nodeItem,
     // dynamicContext);
-    // evaluatePath(Metapath.parseMetapathString("(/catalog//control[@id='ac-1'])"), nodeItem,
+    // evaluatePath(MetapathExpression.compile("/catalog//control//prop/@name"),
+    // nodeItem,
+    // dynamicContext);
+    // evaluatePath(Metapath.parseMetapathString("(/catalog//control[@id='ac-1'])"),
+    // nodeItem,
     // dynamicContext);
   }
 

--- a/src/test/java/gov/nist/secauto/oscal/java/OscalBindingContextTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/java/OscalBindingContextTest.java
@@ -66,7 +66,8 @@ class OscalBindingContextTest {
 
   @Test
   void testLoadCatalogYaml(@TempDir Path tempDir) throws IOException {
-    // the YAML catalog is currently malformed, this will create a proper one for this test
+    // the YAML catalog is currently malformed, this will create a proper one for
+    // this test
     Catalog catalog
         = loader.load(ObjectUtils.notNull(
             new File("target/download/content/NIST_SP-800-53_rev5_catalog.yaml").getCanonicalFile()));

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/DefaultControlSelectionFilterTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/DefaultControlSelectionFilterTest.java
@@ -204,7 +204,8 @@ class DefaultControlSelectionFilterTest {
   }
 
   /**
-   * Test the filtering of a single match criteria using "with-ids" and "with-child=yes".
+   * Test the filtering of a single match criteria using "with-ids" and
+   * "with-child=yes".
    */
   @Test
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")


### PR DESCRIPTION
# Committer Notes

After running `mvn install`, several files become modified in `git status` , but only contain reformatting changes. This PR commits those reformatting changes, so `mvn install` won't clutter `git status` in the future.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oss-maven/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oss-maven/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

~### Changes to Core Features:~

~- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?~
~- [ ] Have you written new tests for your core changes, as applicable?~
~- [ ] Have you included examples of how to use your new feature(s)?~
~- [ ] Have you updated all website and readme documentation affected by the changes you made?~
